### PR TITLE
[FE] feat#16#20

### DIFF
--- a/FE/package.json
+++ b/FE/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -9,7 +9,7 @@ function App() {
       <Routes>
         <Route path="/" element={<MainPage />} />
         <Route path="/game/setup" element={<GameSetupPage />} />
-        <Route path="/game/:id" element={<GamePage />} />
+        <Route path="/game/:gameId" element={<GamePage />} />
         <Route path="*" element={<div>not found</div>} />
       </Routes>
     </Router>

--- a/FE/src/api/socketEventTypes.ts
+++ b/FE/src/api/socketEventTypes.ts
@@ -1,0 +1,165 @@
+// 채팅 메시지 전달 타입
+type ChatMessageRequest = {
+  gameId: string; // PIN
+  message: string;
+};
+
+type ChatMessageResponse = {
+  playerId: string; // socketId
+  playerName: string;
+  message: string;
+  timestamp: Date;
+};
+
+// 플레이어 위치 업데이트 타입
+type UpdatePositionRequest = {
+  newPosition: [number, number];
+};
+
+type UpdatePositionResponse = {
+  playerId: string; // socketId
+  playerPosition: [number, number];
+};
+
+// 게임방 생성 타입
+type CreateRoomRequest = {
+  title: string;
+  gameMode: 'RANKING' | 'SURVIVAL';
+  maxPlayerCount: number;
+  isPublic: boolean;
+};
+
+type CreateRoomResponse = {
+  gameId: string; // PIN
+};
+
+// 게임방 옵션 수정 타입
+type UpdateRoomOptionRequest = {
+  gameId: string;
+  title: string;
+  gameMode: 'RANKING' | 'SURVIVAL';
+  maxPlayerCount: number;
+  isPublic: boolean;
+};
+
+type UpdateRoomOptionResponse = {
+  title: string;
+  gameMode: 'RANKING' | 'SURVIVAL';
+  maxPlayerCount: number;
+  isPublic: boolean;
+};
+
+// 게임방 퀴즈셋 수정 타입
+type UpdateRoomQuizsetRequest = {
+  quizsetId: number;
+  quizCount: number;
+};
+
+type UpdateRoomQuizsetResponse = {
+  quizsetId: number;
+  quizCount: number;
+};
+
+// 게임방 입장 타입
+type JoinRoomRequest = {
+  gameId: string;
+  playerName: string;
+};
+
+type JoinRoomResponse = {
+  players: Array<{
+    playerId: string; // socketId
+    playerName: string;
+    playerPosition: [number, number];
+  }>;
+};
+
+// 게임 시작 타입
+type StartGameRequest = {
+  gameId: string;
+};
+
+type StartGameResponse = Record<string, never>; // 빈 객체
+
+// 게임 정지 타입
+type StopGameRequest = {
+  gameId: string;
+};
+
+type StopGameResponse = {
+  status: string;
+};
+
+// 퀴즈 시간 종료 타입
+type EndQuizTimeEvent = {
+  gameId: string;
+};
+
+// 퀴즈 시작 타입
+type StartQuizTimeEvent = {
+  quiz: string;
+  options: string[];
+  quizEndTime: Date;
+};
+
+// 게임 점수 업데이트 타입
+type UpdateScoreEvent = {
+  scores: Map<string, number>; // Map<playerId, score>
+};
+
+// 게임방 퇴장 타입
+type ExitRoomEvent = {
+  playerId: string;
+};
+
+// 전체 소켓 이벤트 타입 맵
+export type SocketDataMap = {
+  chatMessage: {
+    request: ChatMessageRequest;
+    response: ChatMessageResponse;
+  };
+  updatePosition: {
+    request: UpdatePositionRequest;
+    response: UpdatePositionResponse;
+  };
+  createRoom: {
+    request: CreateRoomRequest;
+    response: CreateRoomResponse;
+  };
+  updateRoomOption: {
+    request: UpdateRoomOptionRequest;
+    response: UpdateRoomOptionResponse;
+  };
+  updateRoomQuizset: {
+    request: UpdateRoomQuizsetRequest;
+    response: UpdateRoomQuizsetResponse;
+  };
+  joinRoom: {
+    request: JoinRoomRequest;
+    response: JoinRoomResponse;
+  };
+  startGame: {
+    request: StartGameRequest;
+    response: StartGameResponse;
+  };
+  stopGame: {
+    request: StopGameRequest;
+    response: StopGameResponse;
+  };
+  endQuizTime: {
+    request: null;
+    response: EndQuizTimeEvent;
+  };
+  startQuizTime: {
+    request: null;
+    response: StartQuizTimeEvent;
+  };
+  updateScore: {
+    request: null;
+    response: UpdateScoreEvent;
+  };
+  exitRoom: {
+    request: null;
+    response: ExitRoomEvent;
+  };
+};

--- a/FE/src/components/Chat.tsx
+++ b/FE/src/components/Chat.tsx
@@ -1,24 +1,12 @@
 import { socketService } from '@/api/socket';
-import { useEffect, useState } from 'react';
-
-const sampleChat = Array(100)
-  .fill(null)
-  .map((_, i) => ({ name: 'user' + i, message: 'messagemessagemessagemessagemessagemessage' }));
+import { useChatStore } from '@/store/useChatStore';
+import { useRoomStore } from '@/store/useRoomStore';
+import { useState } from 'react';
 
 const Chat = () => {
-  const [messages, setMessages] = useState<Array<{ name: string; message: string }>>([]);
+  const gameId = useRoomStore((state) => state.gameId);
+  const messages = useChatStore((state) => state.messages);
   const [inputValue, setInputValue] = useState('');
-
-  useEffect(() => {
-    setMessages(sampleChat); //TODO 나중에 고쳐야 함
-    // 서버에서 메시지를 받을 때
-    // socket.on('chat message', (message) => {
-    //   setMessages((prevMessages) => [...prevMessages, message]);
-    // });
-    // return () => {
-    //   socket.off('chat message');
-    // };
-  }, []);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value);
@@ -27,18 +15,19 @@ const Chat = () => {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (inputValue.trim()) {
-      socketService.chatMessage('1234', inputValue);
+    if (inputValue.trim() && gameId) {
+      socketService.chatMessage(gameId, inputValue);
       setInputValue('');
     }
   };
+
   return (
     <div className="component-default h-[100%]">
       <div className="border-b border-default center h-[2.5rem]">메시지</div>
       <div className="p-2 h-[calc(100%-6rem)] overflow-y-scroll">
         {messages.map((e, i) => (
           <div className="break-words leading-5 mt-3" key={i}>
-            <span className="font-bold mr-2">{e.name}</span>
+            <span className="font-bold mr-2">{e.playerName}</span>
             <span>{e.message}</span>
           </div>
         ))}

--- a/FE/src/components/GameHeader.tsx
+++ b/FE/src/components/GameHeader.tsx
@@ -1,11 +1,12 @@
 import { ClipboardCopy } from './ClipboardCopy';
 import Card from '@mui/material/Card';
 import { QuizPreview } from './QuizView';
+import { useParams } from 'react-router-dom';
 
 export const GameHeader = () => {
-  // 임시값
-  const pinNum = '123456';
-  const linkURL = 'naver.com';
+  const { gameId } = useParams<{ gameId: string }>();
+  const pinNum = String(gameId);
+  const linkURL = window.location.hostname + `/game/${gameId}`;
   return (
     <Card className="p-4 border border-blue-600 shadow-xl rounded-md h-[280px] w-[1000px] bg-gradient-to-b from-blue-500 to-blue-700 text-white">
       <div className="flex justify-center mb-4">
@@ -13,7 +14,7 @@ export const GameHeader = () => {
         <ClipboardCopy valueToCopy={linkURL} message="공유 링크 복사" />
       </div>
       <div className="flex flex-col items-center justify-center text-center space-y-2">
-        <span className="text-xl font-semibold">퀴즈이름22</span>
+        <span className="text-xl font-semibold">퀴즈이름</span>
       </div>
       <QuizPreview title="title" description="퀴즈퀴즈퀴ㅣ즈" />
       <div className="flex space-x-4 justify-center">

--- a/FE/src/components/ParticipantDisplay.tsx
+++ b/FE/src/components/ParticipantDisplay.tsx
@@ -1,15 +1,18 @@
-const samplePalyer = Array(100)
-  .fill(null)
-  .map((_, i) => ({ id: i, name: 'user' + i }));
+import { usePlayerStore } from '@/store/usePlayerStore';
 
 const ParticipantDisplay = () => {
+  const players = usePlayerStore((state) => state.players);
+  console.log(players);
   return (
     <div className="component-default h-[100%]">
       <div className="border-b border-default center h-[2.5rem]">참가자</div>
       <div className="p-3 h-[calc(100%-2.5rem)] overflow-y-scroll">
-        {samplePalyer.map((e, i) => (
-          <div className="flex justify-between mt-2 pb-2 border-b border-default" key={e.id}>
-            <div className="font-bold">{i + 1 + '. ' + e.name}</div>
+        {players.map((player, i) => (
+          <div
+            className="flex justify-between mt-2 pb-2 border-b border-default"
+            key={player.playerId}
+          >
+            <div className="font-bold">{i + 1 + '. ' + player.playerName}</div>
             <button className="bg-main rounded-lg text-white w-8 h-6 text-r">강퇴</button>
           </div>
         ))}

--- a/FE/src/components/Player.tsx
+++ b/FE/src/components/Player.tsx
@@ -1,0 +1,19 @@
+type Props = {
+  name: string;
+  position: [number, number];
+};
+
+export const Player = ({ name, position }: Props) => {
+  const [xPos, yPos] = position;
+  //   const randomX = xPos + Math.floor(Math.random() * 100) + 1; // 1~100 범위의 랜덤값을 xPos에 추가
+  //   const randomY = yPos + Math.floor(Math.random() * 100) + 1;
+
+  const top = xPos * 100 + '%';
+  const left = yPos * 100 + '%';
+  console.log(top, left);
+  return (
+    <div className="absolute transition-all" style={{ top, left }}>
+      {'😀' + name}
+    </div>
+  );
+};

--- a/FE/src/components/QuizOptionBoard.tsx
+++ b/FE/src/components/QuizOptionBoard.tsx
@@ -1,3 +1,5 @@
+import { usePlayerStore } from '@/store/usePlayerStore';
+import { Player } from './Player';
 type Params = {
   options: string[];
 };
@@ -16,17 +18,25 @@ const optionColors = [
 ];
 
 export const QuizOptionBoard = ({ options }: Params) => {
+  const players = usePlayerStore((state) => state.players);
   return (
-    <div className="component-default grid grid-cols-2 h-[100%] gap-4 p-4">
-      {options.map((option, i) => (
-        <div
-          className="rounded-s flex justify-center items-center"
-          key={i}
-          style={{ background: optionColors[i] }}
-        >
-          {i + 1 + '. ' + option}
-        </div>
-      ))}
+    <div className="relative component-default h-[100%]">
+      <div className="absolute h-[100%] w-[100%]">
+        {players.map((player) => (
+          <Player name={player.playerName} position={player.playerPosition} />
+        ))}
+      </div>
+      <div className="grid grid-cols-2 gap-4 p-4 h-[100%] w-[100%]">
+        {options.map((option, i) => (
+          <div
+            className="rounded-s flex justify-center items-center"
+            key={i}
+            style={{ background: optionColors[i] }}
+          >
+            {i + 1 + '. ' + option}
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/FE/src/pages/GamePage.tsx
+++ b/FE/src/pages/GamePage.tsx
@@ -2,21 +2,29 @@ import Chat from '@/components/Chat';
 import ParticipantDisplay from '@/components/ParticipantDisplay';
 import { QuizOptionBoard } from '@/components/QuizOptionBoard';
 import { Modal } from '../components/Modal';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { GameHeader } from '@/components/GameHeader';
 import { HeaderBar } from '@/components/HeaderBar';
-import { useParams } from 'react-router-dom';
 import { socketService } from '@/api/socket';
+import { useParams } from 'react-router-dom';
+import { useRoomStore } from '@/store/useRoomStore';
 
 export const GamePage = () => {
+  const { gameId } = useParams<{ gameId: string }>();
+  const updateRoom = useRoomStore((state) => state.updateRoom);
   const [playerName, setPlayerName] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(true);
-  const pin = useParams();
+
+  updateRoom({ gameId });
+
+  useEffect(() => {
+    if (gameId && playerName) {
+      socketService.joinRoom(gameId, playerName);
+    }
+  }, [gameId, playerName]);
 
   const handleNameSubmit = (name: string) => {
     setPlayerName(name);
-    // 닉네임 설정 소켓 요청
-    socketService.joinRoom(String(pin), name);
     setIsModalOpen(false); // 이름이 설정되면 모달 닫기
   };
 
@@ -29,7 +37,7 @@ export const GamePage = () => {
         </div>
         <div className="grid grid-cols-4 grid-rows-1 gap-4 h-[calc(100%-320px)] p-4">
           <div className="hidden lg:block lg:col-span-1">
-            <Chat></Chat>
+            <Chat />
           </div>
 
           <div className="col-span-4 lg:col-span-2">
@@ -37,7 +45,7 @@ export const GamePage = () => {
           </div>
 
           <div className="hidden lg:block lg:col-span-1">
-            <ParticipantDisplay></ParticipantDisplay>
+            <ParticipantDisplay />
           </div>
 
           <Modal

--- a/FE/src/pages/GameSetupPage.tsx
+++ b/FE/src/pages/GameSetupPage.tsx
@@ -9,15 +9,22 @@ import {
   Radio,
   TextField
 } from '@mui/material';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { socketService } from '@/api/socket';
 import RoomConfig from '@/constants/roomConfig';
-
+import { useNavigate } from 'react-router-dom';
+import { useRoomStore } from '@/store/useRoomStore';
 export const GameSetupPage = () => {
+  const gameId = useRoomStore((state) => state.gameId);
   const [title, setTitle] = useState('');
   const [maxPlayerCount, setMaxPlayerCount] = useState<number>(RoomConfig.DEFAULT_PLAYERS);
   const [gameMode, setGameMode] = useState<'SURVIVAL' | 'RANKING'>('RANKING');
   const [roomPublic, setRoomPublic] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (gameId) navigate(`/game/${gameId}`);
+  }, [gameId, navigate]);
 
   const handleModeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value === 'RANKING' ? 'RANKING' : 'SURVIVAL';
@@ -31,7 +38,6 @@ export const GameSetupPage = () => {
       gameMode,
       isPublic: roomPublic
     };
-
     socketService.createRoom(roomData);
   };
 

--- a/FE/src/store/useChatStore.ts
+++ b/FE/src/store/useChatStore.ts
@@ -1,0 +1,18 @@
+import { socketService } from '@/api/socket';
+import { create } from 'zustand';
+
+type ChatStore = {
+  messages: { playerName: string; message: string }[];
+  addMessage: (playerName: string, message: string) => void;
+};
+
+export const useChatStore = create<ChatStore>((set) => ({
+  messages: [],
+  addMessage: (playerName: string, message: string) => {
+    set((state) => ({ messages: [...state.messages, { playerName, message }] }));
+  }
+}));
+
+socketService.on('chatMessage', (data) => {
+  useChatStore.getState().addMessage(data.playerName, data.message);
+});

--- a/FE/src/store/usePlayerStore.ts
+++ b/FE/src/store/usePlayerStore.ts
@@ -1,0 +1,51 @@
+import { socketService } from '@/api/socket';
+import { create } from 'zustand';
+
+type Player = {
+  playerId: string; // socketId
+  playerName: string;
+  playerPosition: [number, number]; // [x, y] 좌표
+};
+
+type PlayerStore = {
+  players: Player[];
+  addPlayers: (players: Player[]) => void;
+  updatePlayerPosition: (playerId: string, newPosition: [number, number]) => void; // 위치 업데이트
+  removePlayer: (playerId: string) => void;
+};
+
+export const usePlayerStore = create<PlayerStore>((set) => ({
+  players: [],
+
+  addPlayers: (players) => {
+    set((state) => ({
+      players: [...state.players, ...players]
+    }));
+  },
+
+  updatePlayerPosition: (playerId, newPosition) => {
+    set((state) => ({
+      players: state.players.map((player) =>
+        player.playerId === playerId ? { ...player, playerPosition: newPosition } : player
+      )
+    }));
+  },
+
+  removePlayer: (playerId) => {
+    set((state) => ({
+      players: state.players.filter((player) => player.playerId !== playerId)
+    }));
+  }
+}));
+
+socketService.on('joinRoom', (data) => {
+  usePlayerStore.getState().addPlayers(data.players);
+});
+
+socketService.on('updatePosition', (data) => {
+  usePlayerStore.getState().updatePlayerPosition(data.playerId, data.playerPosition);
+});
+
+socketService.on('exitRoom', (data) => {
+  usePlayerStore.getState().removePlayer(data.playerId);
+});

--- a/FE/src/store/useRoomStore.ts
+++ b/FE/src/store/useRoomStore.ts
@@ -1,0 +1,38 @@
+import { socketService } from '@/api/socket';
+import { create } from 'zustand';
+
+type RoomOption = {
+  title?: string;
+  gameMode?: 'RANKING' | 'SURVIVAL';
+  maxPlayerCount?: number;
+  isPublic?: boolean;
+  gameId?: string;
+};
+
+type RoomStore = {
+  title: string;
+  gameMode: 'RANKING' | 'SURVIVAL';
+  maxPlayerCount: number;
+  isPublic: boolean;
+  gameId: string;
+  updateRoom: (roomOption: RoomOption) => void;
+};
+
+export const useRoomStore = create<RoomStore>((set) => ({
+  title: '',
+  gameMode: 'SURVIVAL',
+  maxPlayerCount: 50,
+  isPublic: true,
+  gameId: '',
+  updateRoom: (roomOption: RoomOption) => {
+    set(() => roomOption);
+  }
+}));
+
+socketService.on('createRoom', (data) => {
+  useRoomStore.getState().updateRoom({ gameId: data.gameId });
+});
+
+socketService.on('updateRoomOption', (data) => {
+  useRoomStore.getState().updateRoom(data);
+});


### PR DESCRIPTION
## ➕ 이슈 번호

- #16 
- #20 

<br/>

## 🔎 작업 내용

- 서버와 연동하여 채팅 송수신 가능하도록 구현
- 서버와 연동하여 게임 대기방에서 참가자 목록 보이도록 구현
- 방 설정 및 생성 페이지에서 방 생성 시 게임 페이지로 이동하도록 구현
- 플레이어 보드에 띄움(일단 이모티콘으로)

<br/>

## 🖼 참고 이미지

![image](https://github.com/user-attachments/assets/a5b7d9ba-185b-4d8c-b2eb-2f867b2d06d3)

![image](https://github.com/user-attachments/assets/16b6c608-2690-456c-8b83-b737419dbf67)

<br/>

## 🎯 리뷰 요구사항 (선택)

- 특별히 봐줬으면 하는 부분이 있다면 적어주세요

<br/>

## ✅ Check List

- [X] merge할 브랜치의 위치를 확인했나요?
- [X] Label을 지정했나요?
