### PR TITLE
[BE] feat#47#179 퀴즈셋 cud 구현, test code 작성

### DIFF
--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/mapped-types": "*",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/platform-socket.io": "^10.4.6",
+        "@nestjs/swagger": "^8.0.5",
         "@nestjs/typeorm": "^10.0.2",
         "@nestjs/websockets": "^10.4.7",
         "class-transformer": "^0.5.1",
@@ -1487,6 +1488,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
+      "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA=="
+    },
     "node_modules/@nestjs-modules/ioredis": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@nestjs-modules/ioredis/-/ioredis-2.0.2.tgz",
@@ -1706,9 +1712,9 @@
       }
     },
     "node_modules/@nestjs/mapped-types": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
-      "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.6.tgz",
+      "integrity": "sha512-84ze+CPfp1OWdpRi1/lOu59hOhTz38eVzJvRKrg9ykRFwDz+XleKfMsG0gUqNZYFa6v53XYzeD+xItt8uDW7NQ==",
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "class-transformer": "^0.4.0 || ^0.5.0",
@@ -1840,6 +1846,38 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-8.0.5.tgz",
+      "integrity": "sha512-ZmBdsbQNs3wIN5kCuvAVbz3/ULh3gi814oHTP49uTqAGi1aT0YSatUyncwQOHBOlRT+rwF+TNjoAsZ+twIk/Jw==",
+      "dependencies": {
+        "@microsoft/tsdoc": "^0.15.0",
+        "@nestjs/mapped-types": "2.0.6",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.3.0",
+        "swagger-ui-dist": "5.18.2"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0 || ^7.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@nestjs/terminus": {
       "version": "10.2.0",
@@ -2135,6 +2173,12 @@
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -3046,8 +3090,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -6739,7 +6782,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -8877,6 +8919,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.18.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.2.tgz",
+      "integrity": "sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/BE/package.json
+++ b/BE/package.json
@@ -31,6 +31,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/platform-socket.io": "^10.4.6",
+    "@nestjs/swagger": "^8.0.5",
     "@nestjs/typeorm": "^10.0.2",
     "@nestjs/websockets": "^10.4.7",
     "class-transformer": "^0.5.1",

--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -5,6 +5,14 @@ import { GameModule } from './game/game.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { RedisModule } from '@nestjs-modules/ioredis';
 import { ConfigModule } from '@nestjs/config';
+import { QuizSetModel } from './quiz/entities/quiz-set.entity';
+import { QuizModel } from './quiz/entities/quiz.entity';
+import { QuizChoiceModel } from './quiz/entities/quiz-choice.entity';
+import { UserModel } from './user/entities/user.entity';
+import { UserQuizArchiveModel } from './user/entities/user-quiz-archive.entity';
+import { InitDBModule } from './InitDB/InitDB.module';
+import { UserModule } from './user/user.module';
+import { QuizModule } from './quiz/quiz.module';
 
 @Module({
   imports: [
@@ -32,7 +40,10 @@ import { ConfigModule } from '@nestjs/config';
     RedisModule.forRoot({
       type: 'single',
       url: process.env.REDIS_URL || 'redis://localhost:6379'
-    })
+    }),
+    QuizModule,
+    UserModule,
+    InitDBModule
   ],
   controllers: [AppController],
   providers: [AppService]

--- a/BE/src/quiz/dto/create-quiz.dto.ts
+++ b/BE/src/quiz/dto/create-quiz.dto.ts
@@ -1,12 +1,3 @@
-// export class CreateQuizSetDto extends PickType(QuizSetModel, ['title', 'category', 'quizList']) {}
-//
-// export class CreateQuizDto extends PickType(QuizModel, ['quiz', 'limitTime', 'choiceList']) {}
-//
-// export class CreateChoiceDto extends PickType(QuizChoiceModel, [
-//   'choiceContent',
-//   'choiceOrder',
-//   'isAnswer'
-// ]) {}
 import {
   ArrayMinSize,
   IsArray,
@@ -24,8 +15,6 @@ export class CreateChoiceDto {
   choiceContent: string;
 
   @IsNumber()
-  @Min(1)
-  @Max(10)
   choiceOrder: number;
 
   @IsBoolean()
@@ -37,7 +26,7 @@ export class CreateQuizDto {
   quiz: string;
 
   @IsNumber()
-  @Min(10)
+  @Min(1)
   @Max(3600)
   limitTime: number;
 

--- a/BE/src/quiz/dto/create-quiz.dto.ts
+++ b/BE/src/quiz/dto/create-quiz.dto.ts
@@ -1,1 +1,63 @@
-export class CreateQuizDto {}
+// export class CreateQuizSetDto extends PickType(QuizSetModel, ['title', 'category', 'quizList']) {}
+//
+// export class CreateQuizDto extends PickType(QuizModel, ['quiz', 'limitTime', 'choiceList']) {}
+//
+// export class CreateChoiceDto extends PickType(QuizChoiceModel, [
+//   'choiceContent',
+//   'choiceOrder',
+//   'isAnswer'
+// ]) {}
+import {
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsNumber,
+  IsString,
+  Max,
+  Min,
+  ValidateNested
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateChoiceDto {
+  @IsString()
+  choiceContent: string;
+
+  @IsNumber()
+  @Min(1)
+  @Max(10)
+  choiceOrder: number;
+
+  @IsBoolean()
+  isAnswer: boolean;
+}
+
+export class CreateQuizDto {
+  @IsString()
+  quiz: string;
+
+  @IsNumber()
+  @Min(10)
+  @Max(3600)
+  limitTime: number;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateChoiceDto)
+  @ArrayMinSize(2)
+  choiceList: CreateChoiceDto[];
+}
+
+export class CreateQuizSetDto {
+  @IsString()
+  title: string;
+
+  @IsString()
+  category: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateQuizDto)
+  @ArrayMinSize(1)
+  quizList: CreateQuizDto[];
+}

--- a/BE/src/quiz/dto/update-quiz.dto.ts
+++ b/BE/src/quiz/dto/update-quiz.dto.ts
@@ -1,4 +1,58 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateQuizDto } from './create-quiz.dto';
+import {
+  IsBoolean,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  ValidateNested
+} from 'class-validator';
+import { Type } from 'class-transformer';
 
-export class UpdateQuizDto extends PartialType(CreateQuizDto) {}
+export class UpdateChoiceDto {
+  @IsString()
+  @IsOptional()
+  choiceContent?: string;
+
+  @IsNumber()
+  @IsOptional()
+  @Min(1)
+  @Max(10)
+  choiceOrder?: number;
+
+  @IsBoolean()
+  @IsOptional()
+  isAnswer?: boolean;
+}
+
+export class UpdateQuizDto {
+  @IsString()
+  @IsOptional()
+  quiz?: string;
+
+  @IsNumber()
+  @IsOptional()
+  @Min(10)
+  @Max(3600)
+  limitTime?: number;
+
+  @ValidateNested({ each: true })
+  @Type(() => UpdateChoiceDto)
+  @IsOptional()
+  choiceList?: UpdateChoiceDto[];
+}
+
+export class UpdateQuizSetDto {
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  category?: string;
+
+  @ValidateNested({ each: true })
+  @Type(() => UpdateQuizDto)
+  @IsOptional()
+  quizList?: UpdateQuizDto[];
+}

--- a/BE/src/quiz/quiz.controller.ts
+++ b/BE/src/quiz/quiz.controller.ts
@@ -12,7 +12,7 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { QuizService } from './quiz.service';
-import { UpdateQuizDto } from './dto/update-quiz.dto';
+import { UpdateQuizSetDto } from './dto/update-quiz.dto';
 import { CreateQuizSetDto } from './dto/create-quiz.dto';
 
 @Controller('/api/quizset')
@@ -42,8 +42,8 @@ export class QuizController {
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateQuizDto: UpdateQuizDto) {
-    return this.quizService.update(+id, updateQuizDto);
+  update(@Param('id') id: string, @Body() updateQuizSetDto: UpdateQuizSetDto) {
+    return this.quizService.update(+id, updateQuizSetDto);
   }
 
   @Delete(':id')

--- a/BE/src/quiz/quiz.controller.ts
+++ b/BE/src/quiz/quiz.controller.ts
@@ -31,7 +31,7 @@ export class QuizController {
   findAll(
     @Query('category') category: string,
     @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset: number,
-    @Query('size', new DefaultValuePipe(10), ParseIntPipe) limit: number
+    @Query('size', new DefaultValuePipe(100), ParseIntPipe) limit: number
   ) {
     return this.quizService.findAllWithQuizzesAndChoices(category, offset, limit);
   }

--- a/BE/src/quiz/quiz.controller.ts
+++ b/BE/src/quiz/quiz.controller.ts
@@ -10,17 +10,21 @@ import {
   Post,
   Query
 } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { QuizService } from './quiz.service';
-import { CreateQuizDto } from './dto/create-quiz.dto';
 import { UpdateQuizDto } from './dto/update-quiz.dto';
+import { CreateQuizSetDto } from './dto/create-quiz.dto';
 
 @Controller('/api/quizset')
 export class QuizController {
   constructor(private readonly quizService: QuizService) {}
 
   @Post()
-  create(@Body() createQuizDto: CreateQuizDto) {
-    return this.quizService.create(createQuizDto);
+  @ApiOperation({ summary: '퀴즈셋 생성' })
+  @ApiResponse({ status: 201, description: '퀴즈셋이 성공적으로 생성됨' })
+  @ApiResponse({ status: 400, description: '잘못된 입력값' })
+  async createQuizSet(@Body() createQuizSetDto: CreateQuizSetDto) {
+    return this.quizService.createQuizSet(createQuizSetDto);
   }
 
   @Get()

--- a/BE/src/quiz/quiz.controller.ts
+++ b/BE/src/quiz/quiz.controller.ts
@@ -31,7 +31,7 @@ export class QuizController {
   findAll(
     @Query('category') category: string,
     @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset: number,
-    @Query('size', new DefaultValuePipe(100), ParseIntPipe) limit: number
+    @Query('size', new DefaultValuePipe(10), ParseIntPipe) limit: number
   ) {
     return this.quizService.findAllWithQuizzesAndChoices(category, offset, limit);
   }

--- a/BE/src/quiz/quiz.service.spec.ts
+++ b/BE/src/quiz/quiz.service.spec.ts
@@ -1,80 +1,179 @@
-import { QuizChoiceModel } from './entities/quiz-choice.entity';
-import { QuizSetModel } from './entities/quiz-set.entity';
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { QuizModel } from './entities/quiz.entity';
-import { QuizService } from './quiz.service';
 import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DataSource, QueryRunner } from 'typeorm';
+import { QuizService } from './quiz.service';
+import { QuizSetModel } from './entities/quiz-set.entity';
+import { QuizModel } from './entities/quiz.entity';
+import { QuizChoiceModel } from './entities/quiz-choice.entity';
+import { UserModel } from '../user/entities/user.entity';
+import { CreateQuizSetDto } from './dto/create-quiz.dto';
+import { BadRequestException } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { UserQuizArchiveModel } from '../user/entities/user-quiz-archive.entity';
 
 describe('QuizService', () => {
   let quizService: QuizService;
-  let quizRepository: Repository<QuizModel>;
-  let quizSetRepository: Repository<QuizSetModel>;
-  let quizChoiceRepository: Repository<QuizChoiceModel>;
+  let dataSource: DataSource;
+  let queryRunner: QueryRunner;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        QuizService,
-        {
-          provide: getRepositoryToken(QuizModel),
-          useValue: {
-            findOne: jest.fn()
-          }
-        },
-        {
-          provide: getRepositoryToken(QuizSetModel),
-          useValue: {
-            findOne: jest.fn()
-          }
-        },
-        {
-          provide: getRepositoryToken(QuizChoiceModel),
-          useValue: {
-            findOne: jest.fn()
-          }
-        }
-      ]
+      imports: [
+        ConfigModule.forRoot({
+          envFilePath: '../.env',
+          isGlobal: true
+        }),
+        TypeOrmModule.forRoot({
+          type: 'mysql',
+          host: process.env.DB_HOST || 'localhost',
+          port: +process.env.DB_PORT || 3306,
+          username: process.env.DB_USER,
+          password: process.env.DB_PASSWD,
+          database: process.env.DB_NAME,
+          entities: [QuizSetModel, QuizModel, QuizChoiceModel, UserModel, UserQuizArchiveModel],
+          synchronize: process.env.DEV ? true : false, // 개발 모드에서만 활성화
+          logging: true, // 모든 쿼리 로깅
+          logger: 'advanced-console'
+          // extra: {
+          //   // 글로벌 batch size 설정
+          //   maxBatchSize: 100
+          // }
+        }),
+        TypeOrmModule.forFeature([QuizSetModel, QuizModel, QuizChoiceModel, UserModel])
+      ],
+      providers: [QuizService]
     }).compile();
 
     quizService = module.get<QuizService>(QuizService);
-    quizRepository = module.get<Repository<QuizModel>>(getRepositoryToken(QuizModel));
-    quizSetRepository = module.get<Repository<QuizSetModel>>(getRepositoryToken(QuizSetModel));
-    quizChoiceRepository = module.get<Repository<QuizChoiceModel>>(
-      getRepositoryToken(QuizChoiceModel)
-    );
+    dataSource = module.get<DataSource>(DataSource);
   });
 
-  describe('findOne', () => {
-    it('ID로 알맞은 퀴즈셋을 찾아야 한다.', async () => {
-      // Given
-      const id = 1;
-      // 테스트용 Mock 데이터
-      const mockQuizSet: QuizSetModel = {
-        id: 1,
-        title: 'Test Quiz',
-        userId: 1,
-        category: 'TEST',
-        quizCategoryId: 1,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        deletedAt: null,
-        user: null,
-        quizzes: [],
-        archives: []
-      } as QuizSetModel;
+  beforeEach(async () => {
+    queryRunner = dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+  });
 
-      jest.spyOn(quizSetRepository, 'findOne').mockResolvedValue(mockQuizSet);
+  afterEach(async () => {
+    await queryRunner.rollbackTransaction();
+    await queryRunner.release();
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+  });
+
+  describe('createQuizSet', () => {
+    it('퀴즈셋을 성공적으로 생성해야 한다', async () => {
+      // Given
+      const createQuizSetDto: CreateQuizSetDto = {
+        title: '자바스크립트 기초',
+        category: 'PROGRAMMING',
+        quizList: [
+          {
+            quiz: 'JavaScript의 원시 타입이 아닌 것은?',
+            limitTime: 30,
+            choiceList: [
+              {
+                choiceContent: 'String',
+                choiceOrder: 1,
+                isAnswer: false
+              },
+              {
+                choiceContent: 'Array',
+                choiceOrder: 2,
+                isAnswer: true
+              },
+              {
+                choiceContent: 'Number',
+                choiceOrder: 3,
+                isAnswer: false
+              }
+            ]
+          }
+        ]
+      };
 
       // When
-      const result = await quizService.findOne(id);
+      const result = await quizService.createQuizSet(createQuizSetDto);
 
       // Then
       expect(result).toBeDefined();
-      expect(result).toEqual(mockQuizSet);
-      expect(quizSetRepository.findOne).toHaveBeenCalledWith({
-        where: { id }
+      expect(result.data.id).toBeDefined();
+
+      // 데이터가 정상적으로 저장되었는지 확인
+      const savedQuizSet = await queryRunner.manager.findOne(QuizSetModel, {
+        where: { id: result.data.id },
+        relations: ['quizList', 'quizList.choiceList', 'user']
       });
+
+      expect(savedQuizSet).toBeDefined();
+      expect(savedQuizSet.title).toBe(createQuizSetDto.title);
+      // expect(savedQuizSet.user.email).toBe('honux@codesquad.co.kr');
+      expect(savedQuizSet.quizList).toHaveLength(1);
+      expect(savedQuizSet.quizList[0].choiceList).toHaveLength(3);
+    });
+
+    it('정답이 없는 퀴즈셋 생성 시 에러가 발생해야 한다', async () => {
+      // Given
+      const invalidQuizSetDto: CreateQuizSetDto = {
+        title: '잘못된 퀴즈셋',
+        category: 'PROGRAMMING',
+        quizList: [
+          {
+            quiz: '문제',
+            limitTime: 30,
+            choiceList: [
+              {
+                choiceContent: '보기1',
+                choiceOrder: 1,
+                isAnswer: false
+              },
+              {
+                choiceContent: '보기2',
+                choiceOrder: 2,
+                isAnswer: false
+              }
+            ]
+          }
+        ]
+      };
+
+      // When & Then
+      await expect(quizService.createQuizSet(invalidQuizSetDto)).rejects.toThrow(
+        BadRequestException
+      );
+    });
+
+    it('선택지 번호가 중복된 퀴즈셋 생성 시 에러가 발생해야 한다', async () => {
+      // Given
+      const duplicateOrderQuizSetDto: CreateQuizSetDto = {
+        title: '중복 번호 퀴즈셋',
+        category: 'PROGRAMMING',
+        quizList: [
+          {
+            quiz: '문제',
+            limitTime: 30,
+            choiceList: [
+              {
+                choiceContent: '보기1',
+                choiceOrder: 1,
+                isAnswer: true
+              },
+              {
+                choiceContent: '보기2',
+                choiceOrder: 1,
+                isAnswer: false
+              }
+            ]
+          }
+        ]
+      };
+
+      // When & Then
+      await expect(quizService.createQuizSet(duplicateOrderQuizSetDto)).rejects.toThrow(
+        BadRequestException
+      );
     });
   });
 });

--- a/BE/src/quiz/quiz.service.spec.ts
+++ b/BE/src/quiz/quiz.service.spec.ts
@@ -1,179 +1,83 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { DataSource, QueryRunner } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import { QuizService } from './quiz.service';
-import { QuizSetModel } from './entities/quiz-set.entity';
 import { QuizModel } from './entities/quiz.entity';
+import { QuizSetModel } from './entities/quiz-set.entity';
 import { QuizChoiceModel } from './entities/quiz-choice.entity';
-import { UserModel } from '../user/entities/user.entity';
-import { CreateQuizSetDto } from './dto/create-quiz.dto';
-import { BadRequestException } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
-import { UserQuizArchiveModel } from '../user/entities/user-quiz-archive.entity';
 
 describe('QuizService', () => {
-  let quizService: QuizService;
+  let service: QuizService;
+  let quizRepository: Repository<QuizModel>;
+  let quizSetRepository: Repository<QuizSetModel>;
+  let quizChoiceRepository: Repository<QuizChoiceModel>;
   let dataSource: DataSource;
-  let queryRunner: QueryRunner;
 
-  beforeAll(async () => {
+  const mockRepository = {
+    createQuizSet: jest.fn(),
+    findAllWithQuizzesAndChoices: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn()
+  };
+
+  beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [
-        ConfigModule.forRoot({
-          envFilePath: '../.env',
-          isGlobal: true
-        }),
-        TypeOrmModule.forRoot({
-          type: 'mysql',
-          host: process.env.DB_HOST || 'localhost',
-          port: +process.env.DB_PORT || 3306,
-          username: process.env.DB_USER,
-          password: process.env.DB_PASSWD,
-          database: process.env.DB_NAME,
-          entities: [QuizSetModel, QuizModel, QuizChoiceModel, UserModel, UserQuizArchiveModel],
-          synchronize: process.env.DEV ? true : false, // 개발 모드에서만 활성화
-          logging: true, // 모든 쿼리 로깅
-          logger: 'advanced-console'
-          // extra: {
-          //   // 글로벌 batch size 설정
-          //   maxBatchSize: 100
-          // }
-        }),
-        TypeOrmModule.forFeature([QuizSetModel, QuizModel, QuizChoiceModel, UserModel])
-      ],
-      providers: [QuizService]
+      providers: [
+        QuizService,
+        {
+          provide: getRepositoryToken(QuizModel),
+          useValue: mockRepository
+        },
+        {
+          provide: getRepositoryToken(QuizSetModel),
+          useValue: mockRepository
+        },
+        {
+          provide: getRepositoryToken(QuizChoiceModel),
+          useValue: mockRepository
+        },
+        {
+          provide: DataSource, // DataSource provider
+          useValue: {
+            createQueryRunner: jest.fn(() => ({
+              connect: jest.fn(),
+              startTransaction: jest.fn(),
+              commitTransaction: jest.fn(),
+              rollbackTransaction: jest.fn(),
+              release: jest.fn(),
+              manager: {
+                findOne: jest.fn(),
+                save: jest.fn()
+              }
+            })),
+            transaction: jest.fn((cb) =>
+              cb({
+                findOne: jest.fn(),
+                save: jest.fn()
+              })
+            )
+          }
+        }
+      ]
     }).compile();
 
-    quizService = module.get<QuizService>(QuizService);
+    service = module.get<QuizService>(QuizService);
+    quizRepository = module.get<Repository<QuizModel>>(getRepositoryToken(QuizModel));
+    quizSetRepository = module.get<Repository<QuizSetModel>>(getRepositoryToken(QuizSetModel));
+    quizChoiceRepository = module.get<Repository<QuizChoiceModel>>(
+      getRepositoryToken(QuizChoiceModel)
+    );
     dataSource = module.get<DataSource>(DataSource);
   });
 
-  beforeEach(async () => {
-    queryRunner = dataSource.createQueryRunner();
-    await queryRunner.connect();
-    await queryRunner.startTransaction();
+  it('should be defined', () => {
+    expect(service).toBeDefined();
   });
 
-  afterEach(async () => {
-    await queryRunner.rollbackTransaction();
-    await queryRunner.release();
-  });
-
-  afterAll(async () => {
-    await dataSource.destroy();
-  });
-
-  describe('createQuizSet', () => {
-    it('퀴즈셋을 성공적으로 생성해야 한다', async () => {
-      // Given
-      const createQuizSetDto: CreateQuizSetDto = {
-        title: '자바스크립트 기초',
-        category: 'PROGRAMMING',
-        quizList: [
-          {
-            quiz: 'JavaScript의 원시 타입이 아닌 것은?',
-            limitTime: 30,
-            choiceList: [
-              {
-                choiceContent: 'String',
-                choiceOrder: 1,
-                isAnswer: false
-              },
-              {
-                choiceContent: 'Array',
-                choiceOrder: 2,
-                isAnswer: true
-              },
-              {
-                choiceContent: 'Number',
-                choiceOrder: 3,
-                isAnswer: false
-              }
-            ]
-          }
-        ]
-      };
-
-      // When
-      const result = await quizService.createQuizSet(createQuizSetDto);
-
-      // Then
-      expect(result).toBeDefined();
-      expect(result.data.id).toBeDefined();
-
-      // 데이터가 정상적으로 저장되었는지 확인
-      const savedQuizSet = await queryRunner.manager.findOne(QuizSetModel, {
-        where: { id: result.data.id },
-        relations: ['quizList', 'quizList.choiceList', 'user']
-      });
-
-      expect(savedQuizSet).toBeDefined();
-      expect(savedQuizSet.title).toBe(createQuizSetDto.title);
-      // expect(savedQuizSet.user.email).toBe('honux@codesquad.co.kr');
-      expect(savedQuizSet.quizList).toHaveLength(1);
-      expect(savedQuizSet.quizList[0].choiceList).toHaveLength(3);
-    });
-
-    it('정답이 없는 퀴즈셋 생성 시 에러가 발생해야 한다', async () => {
-      // Given
-      const invalidQuizSetDto: CreateQuizSetDto = {
-        title: '잘못된 퀴즈셋',
-        category: 'PROGRAMMING',
-        quizList: [
-          {
-            quiz: '문제',
-            limitTime: 30,
-            choiceList: [
-              {
-                choiceContent: '보기1',
-                choiceOrder: 1,
-                isAnswer: false
-              },
-              {
-                choiceContent: '보기2',
-                choiceOrder: 2,
-                isAnswer: false
-              }
-            ]
-          }
-        ]
-      };
-
-      // When & Then
-      await expect(quizService.createQuizSet(invalidQuizSetDto)).rejects.toThrow(
-        BadRequestException
-      );
-    });
-
-    it('선택지 번호가 중복된 퀴즈셋 생성 시 에러가 발생해야 한다', async () => {
-      // Given
-      const duplicateOrderQuizSetDto: CreateQuizSetDto = {
-        title: '중복 번호 퀴즈셋',
-        category: 'PROGRAMMING',
-        quizList: [
-          {
-            quiz: '문제',
-            limitTime: 30,
-            choiceList: [
-              {
-                choiceContent: '보기1',
-                choiceOrder: 1,
-                isAnswer: true
-              },
-              {
-                choiceContent: '보기2',
-                choiceOrder: 1,
-                isAnswer: false
-              }
-            ]
-          }
-        ]
-      };
-
-      // When & Then
-      await expect(quizService.createQuizSet(duplicateOrderQuizSetDto)).rejects.toThrow(
-        BadRequestException
-      );
-    });
+  it('repository should be defined', () => {
+    expect(quizRepository).toBeDefined();
+    expect(quizSetRepository).toBeDefined();
+    expect(quizChoiceRepository).toBeDefined();
   });
 });

--- a/BE/src/quiz/quiz.service.ts
+++ b/BE/src/quiz/quiz.service.ts
@@ -133,7 +133,8 @@ export class QuizService {
         limitTime: quiz.limitTime,
         choiceList: (choicesByQuizId[quiz.id] || []).map((choice) => ({
           content: choice.choiceContent,
-          order: choice.choiceOrder
+          order: choice.choiceOrder,
+          isAnswer: choice.isAnswer
         }))
       }))
     };

--- a/BE/src/quiz/quiz.service.ts
+++ b/BE/src/quiz/quiz.service.ts
@@ -65,6 +65,12 @@ export class QuizService {
     const choicesByQuizId = groupBy(choices, 'quizId');
     const quizzesByQuizSetId = groupBy(quizzes, 'quizSetId');
 
+    const dtos = this.quizSetToDto(quizSets, quizzesByQuizSetId, choicesByQuizId);
+
+    return new Result(dtos);
+  }
+
+  private quizSetToDto(quizSets: QuizSetModel[], quizzesByQuizSetId, choicesByQuizId) {
     const dtos = quizSets.map((quizSet) => ({
       id: quizSet.id.toString(),
       title: quizSet.title,
@@ -79,8 +85,7 @@ export class QuizService {
         }))
       }))
     }));
-
-    return new Result(dtos);
+    return dtos;
   }
 
   /**

--- a/BE/test/quiz.e2e-spec.ts
+++ b/BE/test/quiz.e2e-spec.ts
@@ -1,0 +1,380 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DataSource, QueryRunner } from 'typeorm';
+import { BadRequestException } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { QuizService } from '../src/quiz/quiz.service';
+import { QuizSetModel } from '../src/quiz/entities/quiz-set.entity';
+import { QuizModel } from '../src/quiz/entities/quiz.entity';
+import { QuizChoiceModel } from '../src/quiz/entities/quiz-choice.entity';
+import { UserModel } from '../src/user/entities/user.entity';
+import { UserQuizArchiveModel } from '../src/user/entities/user-quiz-archive.entity';
+import { CreateQuizSetDto } from '../src/quiz/dto/create-quiz.dto';
+
+describe('QuizService', () => {
+  let quizService: QuizService;
+  let dataSource: DataSource;
+  let queryRunner: QueryRunner;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          envFilePath: '../.env',
+          isGlobal: true
+        }),
+        TypeOrmModule.forRoot({
+          type: 'mysql',
+          host: process.env.DB_HOST || 'localhost',
+          port: +process.env.DB_PORT || 3306,
+          username: process.env.DB_USER,
+          password: process.env.DB_PASSWD,
+          database: process.env.DB_NAME,
+          entities: [QuizSetModel, QuizModel, QuizChoiceModel, UserModel, UserQuizArchiveModel],
+          synchronize: process.env.DEV ? true : false // 개발 모드에서만 활성화
+          // logging: true, // 모든 쿼리 로깅
+          // logger: 'advanced-console'
+          // extra: {
+          //   // 글로벌 batch size 설정
+          //   maxBatchSize: 100
+          // }
+        }),
+        TypeOrmModule.forFeature([QuizSetModel, QuizModel, QuizChoiceModel, UserModel])
+      ],
+      providers: [QuizService]
+    }).compile();
+
+    quizService = module.get<QuizService>(QuizService);
+    dataSource = module.get<DataSource>(DataSource);
+  });
+
+  beforeEach(async () => {
+    queryRunner = dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+  });
+
+  afterEach(async () => {
+    await queryRunner.rollbackTransaction();
+    await queryRunner.release();
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+  });
+
+  describe('createQuizSet', () => {
+    it('퀴즈셋을 성공적으로 생성해야 한다', async () => {
+      // Given
+      const createQuizSetDto: CreateQuizSetDto = {
+        title: '자바스크립트 기초',
+        category: 'PROGRAMMING',
+        quizList: [
+          {
+            quiz: 'JavaScript의 원시 타입이 아닌 것은?',
+            limitTime: 30,
+            choiceList: [
+              {
+                choiceContent: 'String',
+                choiceOrder: 1,
+                isAnswer: false
+              },
+              {
+                choiceContent: 'Array',
+                choiceOrder: 2,
+                isAnswer: true
+              },
+              {
+                choiceContent: 'Number',
+                choiceOrder: 3,
+                isAnswer: false
+              }
+            ]
+          }
+        ]
+      };
+
+      // When
+      const result = await quizService.createQuizSet(createQuizSetDto);
+
+      // Then
+      expect(result).toBeDefined();
+      expect(result.data.id).toBeDefined();
+
+      // 데이터가 정상적으로 저장되었는지 확인
+      const savedQuizSet = await queryRunner.manager.findOne(QuizSetModel, {
+        where: { id: result.data.id },
+        relations: ['quizList', 'quizList.choiceList', 'user']
+      });
+
+      expect(savedQuizSet).toBeDefined();
+      expect(savedQuizSet.title).toBe(createQuizSetDto.title);
+      // expect(savedQuizSet.user.email).toBe('honux@codesquad.co.kr');
+      expect(savedQuizSet.quizList).toHaveLength(1);
+      expect(savedQuizSet.quizList[0].choiceList).toHaveLength(3);
+    });
+
+    it('정답이 없는 퀴즈셋 생성 시 에러가 발생해야 한다', async () => {
+      // Given
+      const invalidQuizSetDto: CreateQuizSetDto = {
+        title: '잘못된 퀴즈셋',
+        category: 'PROGRAMMING',
+        quizList: [
+          {
+            quiz: '문제',
+            limitTime: 30,
+            choiceList: [
+              {
+                choiceContent: '보기1',
+                choiceOrder: 1,
+                isAnswer: false
+              },
+              {
+                choiceContent: '보기2',
+                choiceOrder: 2,
+                isAnswer: false
+              }
+            ]
+          }
+        ]
+      };
+
+      // When & Then
+      await expect(quizService.createQuizSet(invalidQuizSetDto)).rejects.toThrow(
+        BadRequestException
+      );
+    });
+
+    it('선택지 번호가 중복된 퀴즈셋 생성 시 에러가 발생해야 한다', async () => {
+      // Given
+      const duplicateOrderQuizSetDto: CreateQuizSetDto = {
+        title: '중복 번호 퀴즈셋',
+        category: 'PROGRAMMING',
+        quizList: [
+          {
+            quiz: '문제',
+            limitTime: 30,
+            choiceList: [
+              {
+                choiceContent: '보기1',
+                choiceOrder: 1,
+                isAnswer: true
+              },
+              {
+                choiceContent: '보기2',
+                choiceOrder: 1,
+                isAnswer: false
+              }
+            ]
+          }
+        ]
+      };
+
+      // When & Then
+      await expect(quizService.createQuizSet(duplicateOrderQuizSetDto)).rejects.toThrow(
+        BadRequestException
+      );
+    });
+  });
+
+  describe('findAllWithQuizzesAndChoices', () => {
+    it('카테고리별 퀴즈셋 목록을 가져와야한다', async () => {
+      // Given - 테스트 데이터 생성
+      const createQuizSetDto: CreateQuizSetDto = {
+        title: '자바스크립트 기초',
+        category: 'PROGRAMMING',
+        quizList: [
+          {
+            quiz: '테스트 문제',
+            limitTime: 30,
+            choiceList: [
+              {
+                choiceContent: '보기1',
+                choiceOrder: 1,
+                isAnswer: true
+              },
+              {
+                choiceContent: '보기2',
+                choiceOrder: 2,
+                isAnswer: false
+              }
+            ]
+          }
+        ]
+      };
+
+      await quizService.createQuizSet(createQuizSetDto);
+
+      // When
+      const result = await quizService.findAllWithQuizzesAndChoices('PROGRAMMING', 0, 10);
+
+      // Then
+      expect(result.quizSetList).toBeDefined();
+      expect(result.quizSetList[0].category).toBe('PROGRAMMING');
+      expect(result.quizSetList[0].quizList).toHaveLength(1);
+      expect(result.quizSetList[0].quizList[0].choiceList).toHaveLength(2);
+    });
+
+    it('존재하지 않는 카테고리는 빈 배열을 반환해야 한다', async () => {
+      // When
+      const result = await quizService.findAllWithQuizzesAndChoices('INVALID', 0, 10);
+
+      // Then
+      expect(result.quizSetList).toHaveLength(0);
+    });
+  });
+
+  describe('findOne', () => {
+    let testQuizSet;
+
+    beforeEach(async () => {
+      // Given - 테스트 데이터 생성
+      const dto = {
+        title: '테스트 퀴즈',
+        category: 'TEST',
+        quizList: [
+          {
+            quiz: '문제1',
+            limitTime: 30,
+            choiceList: [
+              {
+                choiceContent: '보기1',
+                choiceOrder: 1,
+                isAnswer: true
+              }
+            ]
+          }
+        ]
+      };
+
+      const result = await quizService.createQuizSet(dto);
+      testQuizSet = result.data;
+    });
+
+    it('ID로 퀴즈셋을 찾을 수 있어야 한다.', async () => {
+      // When
+      const result = await quizService.findOne(testQuizSet.id);
+
+      // Then
+      expect(result).toBeDefined();
+      expect(result.id).toBe(testQuizSet.id.toString());
+      expect(result.quizList).toHaveLength(1);
+      expect(result.quizList[0].choiceList).toHaveLength(1);
+    });
+
+    it('존재하지 않는 ID로 조회시 에러가 발생해야 한다.', async () => {
+      // When & Then
+      await expect(quizService.findOne(999999)).rejects.toThrow();
+    });
+  });
+
+  describe('update', () => {
+    let originQuizSetId;
+
+    beforeEach(async () => {
+      // Given - 테스트용 퀴즈셋 생성
+      const dto = {
+        title: '원본 퀴즈',
+        category: 'TEST',
+        quizList: [
+          {
+            quiz: '원본 문제',
+            limitTime: 30,
+            choiceList: [
+              {
+                choiceContent: '원본 보기',
+                choiceOrder: 1,
+                isAnswer: true
+              }
+            ]
+          }
+        ]
+      };
+
+      const result = await quizService.createQuizSet(dto);
+      originQuizSetId = result.data.id;
+    });
+
+    it('퀴즈셋을 수정할 수 있어야 한다.', async () => {
+      // Given
+      const updateDto = {
+        title: '수정된 퀴즈',
+        category: 'UPDATED',
+        quizList: [
+          {
+            quiz: '수정된 문제',
+            limitTime: 60,
+            choiceList: [
+              {
+                choiceContent: '수정된 보기',
+                choiceOrder: 1,
+                isAnswer: true
+              }
+            ]
+          }
+        ]
+      };
+
+      // When
+      await quizService.update(originQuizSetId, updateDto);
+
+      // Then
+      const updated = await quizService.findOne(originQuizSetId);
+      console.log('updated: ' + JSON.stringify(updated));
+      expect(updated.id).toBe(originQuizSetId.toString());
+      expect(updated.title).toBe('수정된 퀴즈');
+      expect(updated.category).toBe('UPDATED');
+      expect(updated.quizList[0].quiz).toBe('수정된 문제');
+      expect(updated.quizList[0].limitTime).toBe(60);
+    });
+
+    it('존재하지 않는 퀴즈셋 수정시 에러가 발생해야 한다.', async () => {
+      // When & Then
+      await expect(quizService.update(999999, { title: 'test' })).rejects.toThrow();
+    });
+  });
+
+  describe('remove', () => {
+    let testQuizSet;
+
+    beforeEach(async () => {
+      // Given - 테스트용 퀴즈셋 생성
+      const dto = {
+        title: '삭제될 퀴즈',
+        category: 'TEST',
+        quizList: [
+          {
+            quiz: '문제',
+            limitTime: 30,
+            choiceList: [
+              {
+                choiceContent: '보기',
+                choiceOrder: 1,
+                isAnswer: true
+              }
+            ]
+          }
+        ]
+      };
+
+      const result = await quizService.createQuizSet(dto);
+      testQuizSet = result.data;
+    });
+
+    it('퀴즈셋을 soft delete 할 수 있어야 한다.', async () => {
+      // When
+      const result = await quizService.remove(testQuizSet.id);
+
+      // Then
+      expect(result.success).toBe(true);
+
+      // soft delete 되었는지 확인 (일반 조회시 조회 안됨)
+      await expect(quizService.findOne(testQuizSet.id)).rejects.toThrow();
+    });
+
+    it('존재하지 않는 퀴즈셋 삭제시 에러가 발생해야 한다.', async () => {
+      // When & Then
+      await expect(quizService.remove(999999)).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## ➕ 이슈 번호

- #47 
- #179

<br/>

## 🔎 작업 내용
- 개발일지 : https://www.notion.so/s0n9/897a4c8490904f7588b0330f0ea6d73a?p=66de19cbe45d430ab143538c63ed1ec4&pm=s#b072b8bf4e3c422ea657febe6a2ffaee
- 퀴즈셋 c u d 구현
- e2e test code 작성

<br/>

## 🖼 참고 이미지

![image](https://github.com/user-attachments/assets/0388bce9-be97-4be2-bd97-2c487a555c84)
![image](https://github.com/user-attachments/assets/b22f7cd1-1f8c-477c-816c-ee6d55814ab4)
![image](https://github.com/user-attachments/assets/a06d066b-b7ff-41da-8cd9-23a92a8607f2)


<br/>

## 🎯 리뷰 요구사항 (선택)

- e2e test같이 db에 의존적인 test가 자동배포의 test에서 돌아갈런지 알아봐야함.

<br/>

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
