### PR TITLE
[FE] socket.io 연결하는 URL port 수정 (기본값 3000 -> 3333)

### DIFF
--- a/FE/src/api/socket.ts
+++ b/FE/src/api/socket.ts
@@ -99,4 +99,6 @@ class SocketService {
   }
 }
 
-export const socketService = new SocketService('http://' + window.location.hostname + ':3000/game');
+const socketPort = process.env.SOCKET_PORT || '3333';
+const socketUrl = `${window.location.origin}:${socketPort}/game`;
+export const socketService = new SocketService(socketUrl);


### PR DESCRIPTION
## 🔎 작업 내용

- socket 연결 요청은 NginX를 통해 3333으로 받고, 3000번대 포트 was로 보내주는 방식으로 구현되어 있습니다!
- 이에 따라 FE 연결 요청 부분도 수정해서 올렸습니다!

<br/>

## 🖼 참고 이미지

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🎯 리뷰 요구사항 (선택)

- 특별히 봐줬으면 하는 부분이 있다면 적어주세요

<br/>

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
