### PR TITLE
[BE] feat#230 퀴즈셋 목록 조회, 대기방 목록 조회 API 커서 기반 페이징 구현

### DIFF
--- a/BE/src/quiz-set/dto/quiz-set-list-response.dto.ts
+++ b/BE/src/quiz-set/dto/quiz-set-list-response.dto.ts
@@ -1,20 +1,46 @@
 import { Type } from 'class-transformer';
-import { IsString, IsNumber, ValidateNested, IsArray } from 'class-validator';
+import { IsString, IsNumber, ValidateNested, IsArray, IsBoolean, IsObject } from 'class-validator';
 
-export class QuizSetList<T> {
-  constructor(data: T) {
-    this.quizSetList = data;
-  }
+export class PagingDto {
+  @IsString()
+  nextCursor: string | null;
 
-  quizSetList: T;
+  @IsBoolean()
+  hasNextPage: boolean;
 }
 
-export class ChoiceDto {
+export class QuizSetListResponseDto {
+  @ValidateNested({ each: true })
+  @Type(() => QuizSetDto)
+  @IsArray()
+  quizSetList: QuizSetDto[];
+
+  @ValidateNested()
+  @Type(() => PagingDto)
+  @IsObject()
+  paging: PagingDto;
+
+  constructor(quizSetList: QuizSetDto[], nextCursor: string | null, hasNextPage: boolean) {
+    this.quizSetList = quizSetList;
+    this.paging = {
+      nextCursor,
+      hasNextPage
+    };
+  }
+}
+
+export class QuizSetDto {
   @IsString()
-  content: string;
+  id: string;
+
+  @IsString()
+  title: string;
+
+  @IsString()
+  category: string;
 
   @IsNumber()
-  order: number;
+  quizCount: number;
 }
 
 export class QuizDto {
@@ -33,16 +59,10 @@ export class QuizDto {
   choiceList: ChoiceDto[];
 }
 
-export class QuizSetDto {
+export class ChoiceDto {
   @IsString()
-  id: string;
-
-  @IsString()
-  title: string;
-
-  @IsString()
-  category: string;
+  content: string;
 
   @IsNumber()
-  quizCount: number;
+  order: number;
 }

--- a/BE/src/quiz-set/quiz-set.controller.ts
+++ b/BE/src/quiz-set/quiz-set.controller.ts
@@ -29,12 +29,12 @@ export class QuizSetController {
 
   @Get()
   findAll(
-    @Query('category') category: string,
-    @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset: number,
-    @Query('size', new DefaultValuePipe(10), ParseIntPipe) limit: number,
-    @Query('search') search: string
+    @Query('category', new DefaultValuePipe('')) category: string,
+    @Query('cursor', new DefaultValuePipe(1), ParseIntPipe) cursor: number,
+    @Query('take', new DefaultValuePipe(10), ParseIntPipe) take: number,
+    @Query('search', new DefaultValuePipe('')) search: string
   ) {
-    return this.quizService.findAllWithQuizzesAndChoices(category, offset, limit, search);
+    return this.quizService.findAllWithQuizzesAndChoices(category, cursor, take, search);
   }
 
   @Get(':id')

--- a/BE/src/quiz-set/service/quiz-set.service.ts
+++ b/BE/src/quiz-set/service/quiz-set.service.ts
@@ -3,7 +3,7 @@ import {
 } from '@nestjs/common';
 import { CreateQuizSetDto } from '../dto/create-quiz.dto';
 import { UpdateQuizSetDto } from '../dto/update-quiz.dto';
-import { QuizSetDto, QuizSetList } from '../dto/quiz-set-list-response.dto';
+import { QuizSetListResponseDto } from '../dto/quiz-set-list-response.dto';
 import { QuizSetCreateService } from './quiz-set-create.service';
 import { QuizSetReadService } from './quiz-set-read.service';
 import { QuizSetUpdateService } from './quiz-set-update.service';
@@ -30,17 +30,17 @@ export class QuizSetService {
   /**
    * 퀴즈셋 목록을 조회합니다.
    * @param category 카테고리
-   * @param offset 오프셋
-   * @param limit 한 페이지당 개수
+   * @param cursor 오프셋
+   * @param take 한 페이지 당 개수
    * @returns 퀴즈셋 목록
    */
   async findAllWithQuizzesAndChoices(
     category: string,
-    offset: number,
-    limit: number,
+    cursor: number,
+    take: number,
     search: string
-  ): Promise<QuizSetList<QuizSetDto[]>> {
-    return this.quizSetReadService.findAllWithQuizzesAndChoices(category, offset, limit, search);
+  ): Promise<QuizSetListResponseDto> {
+    return this.quizSetReadService.findAllWithQuizzesAndChoices(category, cursor, take, search);
   }
 
   /**

--- a/BE/src/waiting-room/dto/waiting-room-list.response.dto.ts
+++ b/BE/src/waiting-room/dto/waiting-room-list.response.dto.ts
@@ -1,3 +1,5 @@
+import { PagingDto } from '../../quiz-set/dto/quiz-set-list-response.dto';
+
 export class RoomDto {
   title: string;
   gameMode: string;
@@ -5,8 +7,26 @@ export class RoomDto {
   currentPlayerCount: number;
   quizSetTitle: string;
   gameId: string;
+
+  constructor (title: string, gameMode: string, maxPlayerCount: number, currentPlayerCount: number, quizSetTitle: string, gameId: string) {
+    this.title = title;
+    this.gameMode = gameMode;
+    this.maxPlayerCount = maxPlayerCount;
+    this.currentPlayerCount = currentPlayerCount;
+    this.quizSetTitle = quizSetTitle;
+    this.gameId = gameId;
+  }
 }
 
 export class RoomListResponseDto {
   roomList: RoomDto[];
+  paging: PagingDto;
+
+  constructor (roomList: RoomDto[], nextCursor: string, hasNextPage: boolean) {
+    this.roomList = roomList;
+    this.paging = {
+      nextCursor,
+      hasNextPage
+    };
+  }
 }

--- a/BE/src/waiting-room/waiting-room.controller.ts
+++ b/BE/src/waiting-room/waiting-room.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, DefaultValuePipe, Get, ParseIntPipe, Query } from '@nestjs/common';
 import { WaitingRoomService } from './waiting-room.service';
 
 @Controller('/api/rooms')
@@ -6,7 +6,10 @@ export class WaitingRoomController {
   constructor(private readonly waitingRoomService: WaitingRoomService) {}
 
   @Get()
-  async findAll() {
-    return this.waitingRoomService.findAllWaitingRooms();
+  async findAll(
+    @Query('cursor', new DefaultValuePipe(1), ParseIntPipe) cursor: number,
+    @Query('take', new DefaultValuePipe(10), ParseIntPipe) take: number,
+  ) {
+    return this.waitingRoomService.findAllWaitingRooms(cursor, take);
   }
 }

--- a/BE/src/waiting-room/waiting-room.service.ts
+++ b/BE/src/waiting-room/waiting-room.service.ts
@@ -7,7 +7,7 @@ import { RoomDto, RoomListResponseDto } from './dto/waiting-room-list.response.d
 export class WaitingRoomService {
   constructor(@InjectRedis() private readonly redis: Redis) {}
 
-  async findAllWaitingRooms(): Promise<RoomListResponseDto> {
+  async findAllWaitingRooms(cursor: number, take: number): Promise<RoomListResponseDto> {
     const rooms: RoomDto[] = [];
 
     const roomKeys = await this.redis.keys('Room:*');
@@ -16,7 +16,27 @@ export class WaitingRoomService {
       return parts.length === 2 && parts[0] === 'Room';
     });
 
-    for (const roomKey of gameRoomKeys) {
+    // TODO: 현재는 gameId를 기준으로 정렬하고 있으나, 정렬 기준으로 별도로 잡는 게 좋아보임 (redis에 room별로 고유한 id를 부여하거나)
+    gameRoomKeys.sort((a, b) => {
+      const gameIdA = parseInt(a.split(':')[1]);
+      const gameIdB = parseInt(b.split(':')[1]);
+      return gameIdB - gameIdA;
+    });
+
+    // cursor 기반 필터링
+    let startIndex = 0;
+    if (cursor) {
+      const cursorGameId = cursor;
+      startIndex = gameRoomKeys.findIndex(key => key === `Room:${cursorGameId}`) + 1;
+      if (startIndex === 0) { // cursor를 찾지 못한 경우
+        return new RoomListResponseDto([], null, false);
+      }
+    }
+
+    // take + 1개를 가져와서 다음 페이지 존재 여부 확인
+    const targetKeys = gameRoomKeys.slice(startIndex, startIndex + take + 1);
+
+    for (const roomKey of targetKeys) {
       const gameId = roomKey.split(':')[1];
       const roomInfo = await this.redis.hgetall(roomKey);
 
@@ -35,8 +55,10 @@ export class WaitingRoomService {
       });
     }
 
-    return {
-      roomList: rooms
-    };
+    const hasNextPage = rooms.length > take;
+    const responseRooms = hasNextPage ? rooms.slice(0, take) : rooms;
+    const nextCursor = hasNextPage ? responseRooms[responseRooms.length - 1].gameId : null;
+
+    return new RoomListResponseDto(responseRooms, nextCursor, hasNextPage);
   }
 }

--- a/BE/test/integration/quiz.integration.spec.ts
+++ b/BE/test/integration/quiz.integration.spec.ts
@@ -231,6 +231,18 @@ describe('QuizService', () => {
       expect(result.quizSetList).toHaveLength(0);
     });
 
+    it('퀴즈셋 목록 조회 응답에 적절한 커서 응답을 한다', async () => {
+      for (let i = 0; i < 20; i++) {
+        await createQuizSetTestData(quizService, `테스트${i}`);
+      }
+
+      const result = await quizService.findAllWithQuizzesAndChoices('', 0, 10, '');
+
+      expect(result.quizSetList).toHaveLength(10);
+      expect(result.paging.nextCursor).toBe(result.quizSetList[9].id);
+      expect(result.paging.hasNextPage).toBe(true);
+    })
+
     it('검색어로 퀴즈셋 목록을 가져와야 한다', async () => {
       for (let i = 0; i < 20; i++) {
         await createQuizSetTestData(quizService, `테스트${i}`);
@@ -238,8 +250,9 @@ describe('QuizService', () => {
 
       const result = await quizService.findAllWithQuizzesAndChoices('', 0, 10, '테스트19');
 
-      expect(result.quizSetList).toHaveLength(1);
-      expect(result.quizSetList[0].title).toBe('테스트19');
+      result.quizSetList.forEach(quizSet => {
+        expect(quizSet.title).toContain('테스트19');
+      });
     })
 
     it('검색어가 유효하지 않아 퀴즈셋 목록이 없다', async () => {


### PR DESCRIPTION
## ➕ 이슈 번호

- #230

<br/>

## 🔎 작업 내용

- 아직 성능(시간 복잡도)가 좋지는 않습니다. 
- best practice 알아보면서 하려다가, 이렇게 하면 오늘 안에 하기 힘들 것 같아서 우선은 명세에 따라 응답줄 수 있게 구현해뒀습니다. 
  - 정해진 기간 내에 구현하는 것도 중요하다는 말이 머릿속에 스쳐지나가서요!
- 향후 성능 최적화의 대상 중의 하나가 될 수도 있을 것 같습니다. 

<br/>

## 🖼 참고 이미지

<img width="669" alt="image" src="https://github.com/user-attachments/assets/15ca8635-6d74-4d7e-b009-8048541b4343">

<img width="344" alt="image" src="https://github.com/user-attachments/assets/c6385bcb-055f-4536-b295-8553d7a67910">

<br/>

## 🎯 리뷰 요구사항 (선택)

- 감사합니다! 

<br/>

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
