### PR TITLE
[FE] feat#30 강퇴 기능 구현 및 채팅렌더링 최적화

### DIFF
--- a/FE/src/api/socket/socket.ts
+++ b/FE/src/api/socket/socket.ts
@@ -118,6 +118,10 @@ class SocketService {
     this.socket.emit(SocketEvents.JOIN_ROOM, { gameId, playerName });
   }
 
+  kickRoom(gameId: string, kickPlayerId: string) {
+    this.socket.emit(SocketEvents.KICK_ROOM, { gameId, kickPlayerId });
+  }
+
   chatMessage(gameId: string, message: string) {
     this.socket.emit(SocketEvents.CHAT_MESSAGE, { gameId, message });
   }

--- a/FE/src/api/socket/socketEventTypes.ts
+++ b/FE/src/api/socket/socketEventTypes.ts
@@ -123,6 +123,14 @@ type ExitRoomEvent = {
   playerId: string;
 };
 
+type KickRoomRequest = {
+  gameId: string;
+  kickPlayerId: string;
+};
+type KickRoomResponse = {
+  playerId: string;
+};
+
 // 전체 소켓 이벤트 타입 맵
 export type SocketDataMap = {
   chatMessage: {
@@ -184,6 +192,11 @@ export type SocketDataMap = {
       eventName: string;
       message: string;
     };
+  };
+
+  kickRoom: {
+    request: KickRoomRequest;
+    response: KickRoomResponse;
   };
 
   connect: { request: null; response: null };

--- a/FE/src/constants/socketEvents.ts
+++ b/FE/src/constants/socketEvents.ts
@@ -9,7 +9,8 @@ const SocketEvents = {
   STOP_GAME: 'stopGame',
   END_QUIZ_TIME: 'endQuizTime',
   START_QUIZ_TIME: 'startQuizTime',
-  UPDATE_SCORE: 'updateScore'
+  UPDATE_SCORE: 'updateScore',
+  KICK_ROOM: 'kickRoom'
 } as const;
 
 export default SocketEvents;

--- a/FE/src/features/game/components/Chat.tsx
+++ b/FE/src/features/game/components/Chat.tsx
@@ -4,10 +4,11 @@ import { usePlayerStore } from '@/features/game/data/store/usePlayerStore';
 import { useRoomStore } from '@/features/game/data/store/useRoomStore';
 import { Button } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
+import { shallow } from 'zustand/shallow';
 
 const Chat = () => {
   const gameId = useRoomStore((state) => state.gameId);
-  const currentPlayerId = usePlayerStore((state) => state.currentPlayerId);
+  const currentPlayerId = usePlayerStore((state) => state.currentPlayerId, shallow);
   const messages = useChatStore((state) => state.messages);
   const [inputValue, setInputValue] = useState('');
 

--- a/FE/src/features/game/components/Chat.tsx
+++ b/FE/src/features/game/components/Chat.tsx
@@ -4,11 +4,10 @@ import { usePlayerStore } from '@/features/game/data/store/usePlayerStore';
 import { useRoomStore } from '@/features/game/data/store/useRoomStore';
 import { Button } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
-import { shallow } from 'zustand/shallow';
 
 const Chat = () => {
   const gameId = useRoomStore((state) => state.gameId);
-  const currentPlayerId = usePlayerStore((state) => state.currentPlayerId, shallow);
+  const currentPlayerId = usePlayerStore((state) => state.currentPlayerId);
   const messages = useChatStore((state) => state.messages);
   const [inputValue, setInputValue] = useState('');
 

--- a/FE/src/features/game/components/GameHeader.tsx
+++ b/FE/src/features/game/components/GameHeader.tsx
@@ -3,13 +3,13 @@ import Card from '@mui/material/Card';
 import { QuizPreview } from '../../../components/QuizPreview';
 import { useParams } from 'react-router-dom';
 import { useRoomStore } from '@/features/game/data/store/useRoomStore';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { QuizSettingModal } from './QuizSettingModal';
 import { socketService } from '@/api/socket';
 import { usePlayerStore } from '@/features/game/data/store/usePlayerStore';
 import { useQuizStore } from '@/features/game/data/store/useQuizStore';
 
-export const GameHeader = () => {
+export const GameHeader = React.memo(() => {
   const { gameId } = useParams<{ gameId: string }>();
   const isHost = usePlayerStore((state) => state.isHost);
   const gameTitle = useRoomStore((state) => state.title);
@@ -52,4 +52,4 @@ export const GameHeader = () => {
       <QuizSettingModal isOpen={isQuizModalOpen} onClose={() => setIsQuizModalOpen(false)} />
     </Card>
   );
-};
+});

--- a/FE/src/features/game/components/ParticipantDisplay.tsx
+++ b/FE/src/features/game/components/ParticipantDisplay.tsx
@@ -1,3 +1,4 @@
+import { socketService } from '@/api/socket';
 import GameState from '@/constants/gameState';
 import { usePlayerStore } from '@/features/game/data/store/usePlayerStore';
 import { useRoomStore } from '@/features/game/data/store/useRoomStore';
@@ -14,6 +15,11 @@ const ParticipantDisplay: React.FC<ParticipantDisplayProps> = ({ gameState }) =>
   const currentPlayerId = usePlayerStore((state) => state.currentPlayerId);
   const isHost = usePlayerStore((state) => state.isHost);
   const gameMode = useRoomStore((state) => state.gameMode);
+  const gameId = useRoomStore((state) => state.gameId);
+
+  const handleKick = (playerId: string) => {
+    socketService.kickRoom(gameId, playerId);
+  };
 
   // 대기 모드일 때 참가자 목록 표시
   const renderWaitingMode = () => (
@@ -25,7 +31,12 @@ const ParticipantDisplay: React.FC<ParticipantDisplayProps> = ({ gameState }) =>
         >
           <div>{i + 1 + '. ' + player.playerName}</div>
           {isHost && currentPlayerId !== player.playerId && (
-            <button className="bg-main rounded-lg text-white w-8 h-6 text-r">강퇴</button>
+            <button
+              className="bg-main rounded-lg text-white w-8 h-6 text-r"
+              onClick={() => handleKick(player.playerId)}
+            >
+              강퇴
+            </button>
           )}
         </div>
       ))}

--- a/FE/src/features/game/data/socketListener.ts
+++ b/FE/src/features/game/data/socketListener.ts
@@ -127,6 +127,11 @@ socketService.on('endGame', () => {
   useRoomStore.getState().setGameState(GameState.END);
 });
 
+socketService.on('kickRoom', () => {
+  alert('강퇴당하였습니다.');
+  // 메인페이지 or 로비로 이동시키기?
+});
+
 socketService.on('disconnect', () => {
   useRoomStore.getState().reset();
 });


### PR DESCRIPTION
## ➕ 이슈 번호

- #30

<br/>

## 🔎 작업 내용

- 강퇴 기능 구현
- 최적화
  - 리액트 dev tool을 통해 채팅 리렌더링시에 GameHeader도 같이 리렌더링되는 상황파악
  - React.memo를 활용하여 값이 변하지 않았을 경우 리렌더링 되지 않도록 수정
<br/>

## 🖼 참고 이미지
- ### 개선 전
<img src="https://github.com/user-attachments/assets/89246d15-03a6-4106-b9d9-714a66e7e7a7" width="80%" height="80%"/>   

- ### 개선 후
<img src="https://github.com/user-attachments/assets/2dab70ce-f25f-43a9-a6f3-38b211daa12f" width="80%" height="80%"/>
<br/>

## 🎯 리뷰 요구사항 (선택)

- 없음

<br/>

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
