### PR TITLE
[BE] feat#263 강퇴구현, 모니터링 도입

### DIFF
--- a/BE/.eslintrc.js
+++ b/BE/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
     node: true,
     jest: true,
   },
-  ignorePatterns: ['.eslintrc.js'],
+  ignorePatterns: ['.eslintrc.js', 'main.ts'],
   rules: {
     "eqeqeq": "off",
     "curly": "error",

--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -33,6 +33,7 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
+        "pinpoint-node-agent": "^0.8.6",
         "redis": "^4.7.0",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
@@ -830,6 +831,35 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.2.tgz",
+      "integrity": "sha512-bgxdZmgTrJZX50OjyVwz3+mNEnCTNkh3cIqGPWVNeW9jX6bn1ZkU80uPd+67/ZpIJIjRQ9qaHCjhavyoWYxumg==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1472,6 +1502,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@kurkle/color": {
@@ -2238,6 +2277,60 @@
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@redis/bloom": {
       "version": "1.2.0",
@@ -4499,6 +4592,137 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-gateway": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
+      "integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "dependencies": {
+        "execa": "^0.10.0",
+        "ip-regex": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/default-gateway/node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/default-gateway/node_modules/execa": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/default-gateway/node_modules/get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/default-gateway/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-gateway/node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/default-gateway/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/default-gateway/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/default-gateway/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-gateway/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-gateway/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/default-gateway/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -4743,6 +4967,14 @@
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/engine.io": {
@@ -5854,6 +6086,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-protobuf": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ=="
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -6159,6 +6396,35 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/int64-buffer": {
+      "version": "0.99.1007",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.99.1007.tgz",
+      "integrity": "sha512-XDBEu44oSTqlvCSiOZ/0FoUkpWu/vwjJLGSKDabNISPQNZ5wub1FodGHBljRsrR0IXRPq7SslshZYMuA55CgTQ==",
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/internal-ip": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
+      "integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "dependencies": {
+        "default-gateway": "^2.6.0",
+        "ipaddr.js": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ioredis": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.4.1.tgz",
@@ -6202,6 +6468,14 @@
         "ioredis": "^5"
       }
     },
+    "node_modules/ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -6232,7 +6506,6 @@
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
       "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-      "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -7398,6 +7671,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -7476,6 +7754,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/long": {
@@ -7743,6 +8033,11 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
+    },
     "node_modules/moment": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -7867,6 +8162,11 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
@@ -8079,6 +8379,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8254,8 +8562,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -8312,6 +8619,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pinpoint-node-agent": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/pinpoint-node-agent/-/pinpoint-node-agent-0.8.6.tgz",
+      "integrity": "sha512-VNe+dg5+tZJKLJK+Z3eVpog0w34MmUPZZ/O/+IOgwgVX8bVunkOFiMEGe198Y3gD1ZO448QwZljZsI3NlfuV4Q==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.11.0",
+        "end-of-stream": "^1.4.1",
+        "google-protobuf": "^3.13.0",
+        "int64-buffer": "^0.99.1007",
+        "internal-ip": "^3.0.1",
+        "loglevel": "^1.6.1",
+        "methods": "^1.1.2",
+        "require-in-the-middle": "^5.0.3",
+        "semver": "^7.5.3",
+        "shimmer": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.10.0"
       }
     },
     "node_modules/pirates": {
@@ -8560,6 +8887,29 @@
         "node": ">= 6"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -8793,11 +9143,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
+      "integrity": "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -9187,6 +9549,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -9452,6 +9819,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -9533,7 +9908,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },

--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -33,7 +33,7 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
-        "pinpoint-node-agent": "^0.8.6",
+        "pinpoint-node-agent": "^0.9.0-next.0",
         "redis": "^4.7.0",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
@@ -2245,6 +2245,11 @@
         "node": ">=8.0.0",
         "npm": ">=5.0.0"
       }
+    },
+    "node_modules/@pinpoint-apm/shimmer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@pinpoint-apm/shimmer/-/shimmer-1.2.2.tgz",
+      "integrity": "sha512-hhQS4NPgieSoN/nNTkKDdenNYz9Hw4bDyOjtiRKYdWox+BOJ1zt/QWeF37mWvmxe5bhE6rQWTqUgx8BBYT45pA=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4961,6 +4966,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "node_modules/encode-utf8": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-2.0.0.tgz",
+      "integrity": "sha512-3EyMFxZj1/7oMotElDQUEQcP7N4TIe1aJ0m1uBDoyQ8I2LBHhBsXx8P3KsPbqNlGzG+NYxFwEauUwMPHZg3YDQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -5720,6 +5733,14 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/fmix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fmix/-/fmix-1.0.0.tgz",
+      "integrity": "sha512-PIaqOGvVH5P+R92Ywy5PumsNEHvondVQh42SGOmkA9A0ZTFbfguzZpjZ/Gy3WVRUqT9Ia8k5tWlJeiZQzRHA7g==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
@@ -6394,14 +6415,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/int64-buffer": {
-      "version": "0.99.1007",
-      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.99.1007.tgz",
-      "integrity": "sha512-XDBEu44oSTqlvCSiOZ/0FoUkpWu/vwjJLGSKDabNISPQNZ5wub1FodGHBljRsrR0IXRPq7SslshZYMuA55CgTQ==",
-      "engines": {
-        "node": ">= 4.5.0"
       }
     },
     "node_modules/internal-ip": {
@@ -8069,6 +8082,18 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/murmur-128": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmur-128/-/murmur-128-1.0.0.tgz",
+      "integrity": "sha512-lorvQVFjHTqi/exTgKNzqFy0ZJyM6v9oQoJUDGc+MOeVLBm+LfMXMjvQ5rflo5pVRVDPmnxqDMDT9wSkGWPtrA==",
+      "dependencies": {
+        "encode-utf8": "^2.0.0",
+        "fmix": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/mustache": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
@@ -8622,23 +8647,22 @@
       }
     },
     "node_modules/pinpoint-node-agent": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/pinpoint-node-agent/-/pinpoint-node-agent-0.8.6.tgz",
-      "integrity": "sha512-VNe+dg5+tZJKLJK+Z3eVpog0w34MmUPZZ/O/+IOgwgVX8bVunkOFiMEGe198Y3gD1ZO448QwZljZsI3NlfuV4Q==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/pinpoint-node-agent/-/pinpoint-node-agent-0.9.0.tgz",
+      "integrity": "sha512-8jBuyJJ5ulTc5crz1LRFip2pJ7X9j73O9RtYBQVmavTS4eQgEQhlVt1drIKOTiGz+iB4UJ88qI+CQWJS7/MNEg==",
       "dependencies": {
-        "@grpc/grpc-js": "^1.11.0",
+        "@grpc/grpc-js": "^1.2.3",
+        "@pinpoint-apm/shimmer": "^1.2.2",
         "end-of-stream": "^1.4.1",
         "google-protobuf": "^3.13.0",
-        "int64-buffer": "^0.99.1007",
         "internal-ip": "^3.0.1",
         "loglevel": "^1.6.1",
-        "methods": "^1.1.2",
+        "murmur-128": "^1.0.0",
         "require-in-the-middle": "^5.0.3",
-        "semver": "^7.5.3",
-        "shimmer": "^1.2.0"
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=10.10.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/pirates": {
@@ -9548,11 +9572,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "node_modules/side-channel": {
       "version": "1.0.6",

--- a/BE/package.json
+++ b/BE/package.json
@@ -53,7 +53,7 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
-    "pinpoint-node-agent": "^0.8.6",
+    "pinpoint-node-agent": "^0.9.0-next.0",
     "redis": "^4.7.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",

--- a/BE/package.json
+++ b/BE/package.json
@@ -53,6 +53,7 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
+    "pinpoint-node-agent": "^0.8.6",
     "redis": "^4.7.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",

--- a/BE/src/common/constants/exception-message.ts
+++ b/BE/src/common/constants/exception-message.ts
@@ -5,5 +5,6 @@ export const ExceptionMessage = {
   ONLY_HOST: '방장이 아닙니다.',
   GAME_NOT_STARTED: '게임이 시작되지 않았습니다.',
   EXCEEDS_QUIZ_SET_LIMIT: '선택된 퀴즈 수가 퀴즈셋에 있는 퀴즈 수를 초과했습니다.',
-  GAME_ALREADY_STARTED: '게임이 이미 시작되었습니다.'
+  GAME_ALREADY_STARTED: '게임이 이미 시작되었습니다.',
+  PLAYER_NOT_FOUND: '존재하지 않는 플레이어입니다.'
 };

--- a/BE/src/common/constants/socket-events.ts
+++ b/BE/src/common/constants/socket-events.ts
@@ -10,7 +10,8 @@ const SocketEvents = {
   END_QUIZ_TIME: 'endQuizTime',
   START_QUIZ_TIME: 'startQuizTime',
   UPDATE_SCORE: 'updateScore',
-  EXIT_ROOM: 'exitRoom'
+  EXIT_ROOM: 'exitRoom',
+  KICK_ROOM: 'kickRoom'
 } as const;
 
 export default SocketEvents;

--- a/BE/src/game/dto/kick-room.dto.ts
+++ b/BE/src/game/dto/kick-room.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, Length } from 'class-validator';
+
+export class KickRoomDto {
+  @IsString()
+  @Length(6, 6, { message: 'PIN번호는 6자리이어야 합니다.' })
+  gameId: string;
+
+  @IsString()
+  kickPlayerId: string;
+}

--- a/BE/src/game/game.gateway.ts
+++ b/BE/src/game/game.gateway.ts
@@ -22,6 +22,7 @@ import { GameChatService } from './service/game.chat.service';
 import { GameRoomService } from './service/game.room.service';
 import { WsJwtAuthGuard } from '../auth/guard/ws-jwt-auth.guard';
 import { GameActivityInterceptor } from './interceptor/gameActivity.interceptor';
+import { KickRoomDto } from './dto/kick-room.dto';
 
 @UseInterceptors(GameActivityInterceptor)
 @UseFilters(new WsExceptionFilter())
@@ -109,6 +110,12 @@ export class GameGateway {
     @ConnectedSocket() client: Socket
   ) {
     await this.gameService.startGame(startGameDto, client.id);
+  }
+
+  @SubscribeMessage(SocketEvents.KICK_ROOM)
+  @UsePipes(new GameValidationPipe(SocketEvents.KICK_ROOM))
+  async handleKickRoom(@MessageBody() kickRoomDto: KickRoomDto, @ConnectedSocket() client: Socket) {
+    await this.gameRoomService.kickRoom(kickRoomDto, client.id);
   }
 
   afterInit() {

--- a/BE/src/game/redis/subscribers/player.subscriber.ts
+++ b/BE/src/game/redis/subscribers/player.subscriber.ts
@@ -50,6 +50,9 @@ export class PlayerSubscriber extends RedisSubscriber {
       case 'Disconnect':
         await this.handlePlayerDisconnect(playerId, playerData, server);
         break;
+      case 'Kicked':
+        await this.handlePlayerKicked(playerId, playerData, server);
+        break;
     }
   }
 
@@ -79,5 +82,14 @@ export class PlayerSubscriber extends RedisSubscriber {
       playerId
     });
     this.logger.verbose(`Player disconnected: ${playerId} from game: ${playerData.gameId}`);
+  }
+
+  private async handlePlayerKicked(playerId: string, playerData: any, server: Server) {
+    server.to(playerData.gameId).emit(SocketEvents.KICK_ROOM, {
+      playerId
+    });
+    this.logger.verbose(`Player kicked: ${playerId} from game: ${playerData.gameId}`);
+    //클라에서 exitRoom도 주기를 원함
+    await this.handlePlayerDisconnect(playerId, playerData, server);
   }
 }

--- a/BE/src/game/validations/game.validator.ts
+++ b/BE/src/game/validations/game.validator.ts
@@ -39,4 +39,10 @@ export class GameValidator {
       throw new GameWsException(eventName, ExceptionMessage.GAME_ALREADY_STARTED);
     }
   }
+
+  validatePlayerExists(eventName: string, targetPlayer: any) {
+    if (!targetPlayer) {
+      throw new GameWsException(eventName, ExceptionMessage.PLAYER_NOT_FOUND);
+    }
+  }
 }

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -1,7 +1,12 @@
+import { config } from 'dotenv';
+import { join } from 'path';
+import 'pinpoint-node-agent';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { Logger } from '@nestjs/common';
 import { GameActivityInterceptor } from './game/interceptor/gameActivity.interceptor';
+// env 불러오기
+config({ path: join(__dirname, '..', '.env') }); // ../ 경로의 .env 로드
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);


### PR DESCRIPTION
## ➕ 이슈 번호

- #263 

<br/>

## 🔎 작업 내용
- https://www.notion.so/s0n9/897a4c8490904f7588b0330f0ea6d73a?p=5a1e14f717e84d5a9957a261b5550eb6&pm=s
- 강퇴기능 구현, 재입장 불가는 todo
- 핀포인트 도입 
  - socket io 미지원
  - nestjs지원 && socket io 를 모니터링 하는 도구를 찾거나 직접 (로거 수준으로) 구현해야할듯
  - 세세한 api 분석 측면에서는 엄청 강력한 툴 맞음.
  - cpu, mem, db conn등 큰그림을 보려면 프로메테우스 도입필요 할듯.


<br/>

## 🖼 참고 이미지

![image](https://github.com/user-attachments/assets/defcf738-bdad-4953-924f-97ac7715e1eb)
![image](https://github.com/user-attachments/assets/5a197cfb-636c-4b77-a01d-ae4d04930b95)


<br/>

## 🎯 리뷰 요구사항 (선택)

- 소켓도 지원되게 도전?
- 원래는 모니터링용 서버를 하나 더 띄우는게 정석, 일단 was 서버에 넣어놓음.

<br/>

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
