### PR TITLE
[BE] feat#229 모니터링 인터셉터 구현

### DIFF
--- a/BE/src/common/interceptor/SocketEventLoggerInterceptor.ts
+++ b/BE/src/common/interceptor/SocketEventLoggerInterceptor.ts
@@ -1,0 +1,87 @@
+/**
+ * @class SocketEventLoggerInterceptor
+ * @description WebSocket 이벤트 실행 시간과 메서드 정보를 로깅하는 인터셉터
+ */
+import { CallHandler, ExecutionContext, Injectable, Logger, NestInterceptor } from '@nestjs/common';
+import { Observable, tap } from 'rxjs';
+import { Socket } from 'socket.io';
+
+interface SocketEventLog {
+  className: string;
+  methodName: string;
+  event: string;
+  clientId: string;
+  executionTime: number;
+  timestamp: string;
+  payload?: any;
+}
+
+@Injectable()
+export class SocketEventLoggerInterceptor implements NestInterceptor {
+  private readonly logger = new Logger('SocketEventLogger');
+  private readonly EXECUTION_TIME_THRESHOLD = 1000;
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    if (context.getType() !== 'ws') {
+      return next.handle();
+    }
+
+    const startTime = Date.now();
+    const ctx = context.switchToWs();
+    const client: Socket = ctx.getClient();
+    const event = ctx.getData();
+
+    // 현재 실행 중인 클래스와 메서드 정보 가져오기
+    const className = context.getClass().name;
+    const methodName = context.getHandler().name;
+
+    return next.handle().pipe(
+      tap({
+        next: (data) => {
+          const executionTime = Date.now() - startTime;
+
+          const logData: SocketEventLog = {
+            className,
+            methodName,
+            event: typeof event === 'object' ? JSON.stringify(event) : event,
+            clientId: client.id,
+            executionTime,
+            timestamp: new Date().toISOString(),
+            payload: data
+          };
+
+          if (executionTime >= this.EXECUTION_TIME_THRESHOLD) {
+            this.logger.warn(
+              '🐢 Slow Socket Event Detected!\n' +
+                `Class: ${logData.className}\n` +
+                `Method: ${logData.methodName}\n` +
+                `Event: ${logData.event}\n` +
+                `Client: ${logData.clientId}\n` +
+                `Execution Time: ${logData.executionTime}ms\n` +
+                `Timestamp: ${logData.timestamp}`
+            );
+          } else {
+            this.logger.log(
+              '🚀 Socket Event Processed\n' +
+                `Class: ${logData.className}\n` +
+                `Method: ${logData.methodName}\n` +
+                `Event: ${logData.event}\n` +
+                `Client: ${logData.clientId}\n` +
+                `Execution Time: ${logData.executionTime}ms`
+            );
+          }
+        },
+        error: (error) => {
+          this.logger.error(
+            '❌ Socket Event Error\n' +
+              `Class: ${className}\n` +
+              `Method: ${methodName}\n` +
+              `Event: ${event}\n` +
+              `Client: ${client.id}\n` +
+              `Error: ${error.message}`
+          );
+        }
+      })
+    );
+  }
+}

--- a/BE/src/common/interceptor/SocketEventLoggerInterceptor.ts
+++ b/BE/src/common/interceptor/SocketEventLoggerInterceptor.ts
@@ -1,25 +1,60 @@
-/**
- * @class SocketEventLoggerInterceptor
- * @description WebSocket 이벤트 실행 시간과 메서드 정보를 로깅하는 인터셉터
- */
+import { firstValueFrom, Observable } from 'rxjs';
 import { CallHandler, ExecutionContext, Injectable, Logger, NestInterceptor } from '@nestjs/common';
-import { Observable, tap } from 'rxjs';
+import { ModuleRef } from '@nestjs/core';
 import { Socket } from 'socket.io';
+import { AsyncLocalStorage } from 'async_hooks'; // 이 부분 추가
 
-interface SocketEventLog {
-  className: string;
-  methodName: string;
-  event: string;
-  clientId: string;
-  executionTime: number;
-  timestamp: string;
-  payload?: any;
+/**
+ * @class TraceStore
+ * @description 함수 호출 추적을 위한 저장소
+ */
+export class TraceStore {
+  private static instance = new AsyncLocalStorage<TraceContext>();
+
+  static getStore() {
+    return this.instance;
+  }
 }
 
+/**
+ * @class TraceContext
+ * @description 추적 컨텍스트
+ */
+class TraceContext {
+  private depth = 0;
+  private logs: string[] = [];
+
+  increaseDepth() {
+    this.depth++;
+  }
+
+  decreaseDepth() {
+    this.depth--;
+  }
+
+  addLog(message: string) {
+    const indent = '  '.repeat(this.depth);
+    this.logs.push(`${indent}${message}`);
+  }
+
+  getLogs(): string[] {
+    return this.logs;
+  }
+}
+
+// 전역 AsyncLocalStorage 인스턴스
+export const traceStore = new AsyncLocalStorage<TraceContext>();
+
+/**
+ * @class SocketEventLoggerInterceptor
+ * @description WebSocket 이벤트와 서비스 호출을 로깅하는 인터셉터
+ */
 @Injectable()
 export class SocketEventLoggerInterceptor implements NestInterceptor {
   private readonly logger = new Logger('SocketEventLogger');
   private readonly EXECUTION_TIME_THRESHOLD = 1000;
+
+  constructor(private readonly moduleRef: ModuleRef) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     if (context.getType() !== 'ws') {
@@ -30,58 +65,149 @@ export class SocketEventLoggerInterceptor implements NestInterceptor {
     const ctx = context.switchToWs();
     const client: Socket = ctx.getClient();
     const event = ctx.getData();
-
-    // 현재 실행 중인 클래스와 메서드 정보 가져오기
     const className = context.getClass().name;
     const methodName = context.getHandler().name;
 
-    return next.handle().pipe(
-      tap({
-        next: (data) => {
-          const executionTime = Date.now() - startTime;
+    // 새로운 추적 컨텍스트 시작
+    const traceContext = new TraceContext();
 
-          const logData: SocketEventLog = {
-            className,
-            methodName,
-            event: typeof event === 'object' ? JSON.stringify(event) : event,
-            clientId: client.id,
-            executionTime,
-            timestamp: new Date().toISOString(),
-            payload: data
-          };
+    return new Observable((subscriber) => {
+      // AsyncLocalStorage를 사용하여 추적 컨텍스트 설정
+      TraceStore.getStore().run(traceContext, async () => {
+        try {
+          // 핸들러 실행 전 로그
+          traceContext.addLog(`[${className}.${methodName}] Started`);
+
+          // 원본 핸들러 실행
+          const result = await firstValueFrom(next.handle());
+
+          const executionTime = Date.now() - startTime;
+          const logs = traceContext.getLogs();
 
           if (executionTime >= this.EXECUTION_TIME_THRESHOLD) {
             this.logger.warn(
               '🐢 Slow Socket Event Detected!\n' +
-                `Class: ${logData.className}\n` +
-                `Method: ${logData.methodName}\n` +
-                `Event: ${logData.event}\n` +
-                `Client: ${logData.clientId}\n` +
-                `Execution Time: ${logData.executionTime}ms\n` +
-                `Timestamp: ${logData.timestamp}`
+                logs.join('\n') +
+                `\nTotal Execution Time: ${executionTime}ms`
             );
           } else {
             this.logger.log(
               '🚀 Socket Event Processed\n' +
-                `Class: ${logData.className}\n` +
-                `Method: ${logData.methodName}\n` +
-                `Event: ${logData.event}\n` +
-                `Client: ${logData.clientId}\n` +
-                `Execution Time: ${logData.executionTime}ms`
+                logs.join('\n') +
+                `\nTotal Execution Time: ${executionTime}ms`
             );
           }
-        },
-        error: (error) => {
+
+          subscriber.next(result);
+          subscriber.complete();
+        } catch (error) {
+          const logs = traceContext.getLogs();
           this.logger.error(
-            '❌ Socket Event Error\n' +
-              `Class: ${className}\n` +
-              `Method: ${methodName}\n` +
-              `Event: ${event}\n` +
-              `Client: ${client.id}\n` +
-              `Error: ${error.message}`
+            '❌ Socket Event Error\n' + logs.join('\n') + `\nError: ${error.message}`
           );
+          subscriber.error(error);
         }
-      })
-    );
+      });
+    });
   }
+}
+
+/**
+ * @function Trace
+ * @description 서비스 메서드 추적을 위한 데코레이터
+ */
+export function Trace() {
+  return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+    const originalMethod = descriptor.value;
+
+    descriptor.value = async function (...args: any[]) {
+      const className = target.constructor.name;
+      const startTime = Date.now();
+
+      const traceContext = TraceStore.getStore().getStore();
+      if (traceContext) {
+        traceContext.increaseDepth();
+        traceContext.addLog(`[${className}.${propertyKey}] Started`);
+      }
+
+      try {
+        const result = await originalMethod.apply(this, args);
+
+        if (traceContext) {
+          const executionTime = Date.now() - startTime;
+          traceContext.addLog(`[${className}.${propertyKey}] Completed (${executionTime}ms)`);
+          traceContext.decreaseDepth();
+        }
+
+        return result;
+      } catch (error) {
+        if (traceContext) {
+          const executionTime = Date.now() - startTime;
+          traceContext.addLog(
+            `[${className}.${propertyKey}] Failed (${executionTime}ms): ${error.message}`
+          );
+          traceContext.decreaseDepth();
+        }
+        throw error;
+      }
+    };
+
+    return descriptor;
+  };
+}
+
+/**
+ * @function TraceClass
+ * @description 클래스의 모든 메서드에 추적을 적용하는 데코레이터
+ */
+export function TraceClass() {
+  return function <T extends { new (...args: any[]): {} }>(constructor: T) {
+    // 프로토타입의 모든 메서드를 가져옴
+    const methods = Object.getOwnPropertyNames(constructor.prototype);
+
+    methods.forEach((methodName) => {
+      // constructor와 private/protected 메서드 제외
+      if (methodName === 'constructor' || methodName.startsWith('_')) {
+        return;
+      }
+
+      const descriptor = Object.getOwnPropertyDescriptor(constructor.prototype, methodName);
+
+      if (descriptor && typeof descriptor.value === 'function') {
+        const originalMethod = descriptor.value;
+
+        descriptor.value = async function (...args: any[]) {
+          const traceContext = traceStore.getStore();
+          if (!traceContext) {
+            return originalMethod.apply(this, args);
+          }
+
+          const startTime = Date.now();
+          const className = constructor.name;
+
+          traceContext.increaseDepth();
+          traceContext.addLog(`[${className}.${methodName}] Started`);
+
+          try {
+            const result = await originalMethod.apply(this, args);
+            const executionTime = Date.now() - startTime;
+            traceContext.addLog(`[${className}.${methodName}] Completed (${executionTime}ms)`);
+            traceContext.decreaseDepth();
+            return result;
+          } catch (error) {
+            const executionTime = Date.now() - startTime;
+            traceContext.addLog(
+              `[${className}.${methodName}] Failed (${executionTime}ms): ${error.message}`
+            );
+            traceContext.decreaseDepth();
+            throw error;
+          }
+        };
+
+        Object.defineProperty(constructor.prototype, methodName, descriptor);
+      }
+    });
+
+    return constructor;
+  };
 }

--- a/BE/src/game/game.gateway.ts
+++ b/BE/src/game/game.gateway.ts
@@ -23,7 +23,9 @@ import { GameRoomService } from './service/game.room.service';
 import { WsJwtAuthGuard } from '../auth/guard/ws-jwt-auth.guard';
 import { GameActivityInterceptor } from './interceptor/gameActivity.interceptor';
 import { KickRoomDto } from './dto/kick-room.dto';
+import { SocketEventLoggerInterceptor } from '../common/interceptor/SocketEventLoggerInterceptor';
 
+@UseInterceptors(SocketEventLoggerInterceptor)
 @UseInterceptors(GameActivityInterceptor)
 @UseFilters(new WsExceptionFilter())
 @WebSocketGateway({
@@ -42,6 +44,15 @@ export class GameGateway {
     private readonly gameChatService: GameChatService,
     private readonly gameRoomService: GameRoomService
   ) {}
+
+  @SubscribeMessage('slowEvent')
+  async handleSlowEvent(@ConnectedSocket() client: Socket): Promise<void> {
+    // 의도적으로 지연 발생시키는 테스트 코드
+    await this.gameService.longBusinessLogic();
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    // 실제 로직
+    // ...
+  }
 
   @SubscribeMessage(SocketEvents.CREATE_ROOM)
   @UsePipes(new GameValidationPipe(SocketEvents.CREATE_ROOM))

--- a/BE/src/game/service/game.room.service.ts
+++ b/BE/src/game/service/game.room.service.ts
@@ -12,8 +12,9 @@ import { UpdateRoomQuizsetDto } from '../dto/update-room-quizset.dto';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { Socket } from 'socket.io';
 import { KickRoomDto } from '../dto/kick-room.dto';
-import { Trace } from '../../common/interceptor/SocketEventLoggerInterceptor';
+import { TraceClass } from '../../common/interceptor/SocketEventLoggerInterceptor';
 
+@TraceClass()
 @Injectable()
 export class GameRoomService {
   private readonly logger = new Logger(GameRoomService.name);
@@ -25,7 +26,6 @@ export class GameRoomService {
     private readonly gameValidator: GameValidator
   ) {}
 
-  @Trace()
   async createRoom(gameConfig: CreateGameDto, clientId: string): Promise<string> {
     const currentRoomPins = await this.redis.smembers(REDIS_KEY.ACTIVE_ROOMS);
     const roomId = generateUniquePin(currentRoomPins);
@@ -51,7 +51,6 @@ export class GameRoomService {
     return roomId;
   }
 
-  @Trace()
   async joinRoom(client: Socket, dto: JoinRoomDto, clientId: string) {
     const roomKey = REDIS_KEY.ROOM(dto.gameId);
     const room = await this.redis.hgetall(roomKey);

--- a/BE/src/game/service/game.room.service.ts
+++ b/BE/src/game/service/game.room.service.ts
@@ -12,6 +12,7 @@ import { UpdateRoomQuizsetDto } from '../dto/update-room-quizset.dto';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { Socket } from 'socket.io';
 import { KickRoomDto } from '../dto/kick-room.dto';
+import { Trace } from '../../common/interceptor/SocketEventLoggerInterceptor';
 
 @Injectable()
 export class GameRoomService {
@@ -24,6 +25,7 @@ export class GameRoomService {
     private readonly gameValidator: GameValidator
   ) {}
 
+  @Trace()
   async createRoom(gameConfig: CreateGameDto, clientId: string): Promise<string> {
     const currentRoomPins = await this.redis.smembers(REDIS_KEY.ACTIVE_ROOMS);
     const roomId = generateUniquePin(currentRoomPins);
@@ -49,6 +51,7 @@ export class GameRoomService {
     return roomId;
   }
 
+  @Trace()
   async joinRoom(client: Socket, dto: JoinRoomDto, clientId: string) {
     const roomKey = REDIS_KEY.ROOM(dto.gameId);
     const room = await this.redis.hgetall(roomKey);

--- a/BE/src/game/service/game.service.ts
+++ b/BE/src/game/service/game.service.ts
@@ -10,6 +10,7 @@ import { Server } from 'socket.io';
 import { mockQuizData } from '../../../test/mocks/quiz-data.mock';
 import { QuizCacheService } from './quiz.cache.service';
 import { RedisSubscriberService } from '../redis/redis-subscriber.service';
+import { Trace } from '../../common/interceptor/SocketEventLoggerInterceptor';
 
 @Injectable()
 export class GameService {
@@ -159,6 +160,7 @@ export class GameService {
     }
   }
 
+  @Trace()
   async longBusinessLogic() {
     this.logger.verbose('longBusinessLogic start');
     await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/BE/src/game/service/game.service.ts
+++ b/BE/src/game/service/game.service.ts
@@ -158,4 +158,10 @@ export class GameService {
       await this.redis.del(roomLeaderboardKey);
     }
   }
+
+  async longBusinessLogic() {
+    this.logger.verbose('longBusinessLogic start');
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    this.logger.verbose('longBusinessLogic end');
+  }
 }

--- a/BE/src/game/service/game.service.ts
+++ b/BE/src/game/service/game.service.ts
@@ -10,8 +10,9 @@ import { Server } from 'socket.io';
 import { mockQuizData } from '../../../test/mocks/quiz-data.mock';
 import { QuizCacheService } from './quiz.cache.service';
 import { RedisSubscriberService } from '../redis/redis-subscriber.service';
-import { Trace } from '../../common/interceptor/SocketEventLoggerInterceptor';
+import { Trace, TraceClass } from '../../common/interceptor/SocketEventLoggerInterceptor';
 
+@TraceClass()
 @Injectable()
 export class GameService {
   private readonly logger = new Logger(GameService.name);

--- a/BE/src/game/service/quiz.cache.service.ts
+++ b/BE/src/game/service/quiz.cache.service.ts
@@ -5,7 +5,9 @@ import { Redis } from 'ioredis';
 import { mockQuizData } from '../../../test/mocks/quiz-data.mock';
 import { REDIS_KEY } from '../../common/constants/redis-key.constant';
 import { QuizSetService } from '../../quiz-set/service/quiz-set.service';
+import { TraceClass } from '../../common/interceptor/SocketEventLoggerInterceptor';
 
+@TraceClass()
 @Injectable()
 export class QuizCacheService {
   private readonly quizCache = new Map<string, any>();


### PR DESCRIPTION
## ➕ 이슈 번호

- #229 

<br/>

## 🔎 작업 내용
이 풀 리퀘스트는 백엔드 애플리케이션의 WebSocket 이벤트와 서비스 메서드에 대한 포괄적인 로깅 및 추적 기능을 도입합니다. 변경 사항에는 소켓 이벤트를 로깅하기 위한 새로운 인터셉터와 메서드 호출 및 실행 시간을 추적하기 위한 데코레이터 구현이 포함됩니다.
주요 변경 사항:

### 로깅 및 추적 구현:
* `BE/src/common/interceptor/SocketEventLoggerInterceptor.ts`: WebSocket 이벤트와 서비스 메서드 호출을 로깅하기 위한 `SocketEventLoggerInterceptor` 추가. `AsyncLocalStorage`를 사용하여 추적 컨텍스트를 관리하는 `TraceStore`와 `TraceContext` 클래스 도입. 서비스 메서드와 클래스를 추적하기 위한 `Trace`와 `TraceClass` 데코레이터 구현.

### WebSocket 게이트웨이 통합:
* `BE/src/game/game.gateway.ts`: 소켓 이벤트를 로깅하기 위해 WebSocket 게이트웨이에 `SocketEventLoggerInterceptor` 통합. 테스트 목적으로 느린 이벤트를 시뮬레이션하고 로깅하기 위한 새로운 `handleSlowEvent` 메서드 추가.

### 서비스 클래스에서의 추적:
* `BE/src/game/service/game.chat.service.ts`: 모든 메서드의 추적을 활성화하기 위해 `GameChatService` 클래스에 `TraceClass` 데코레이터 적용.
* `BE/src/game/service/game.room.service.ts`: 메서드 추적을 위해 `GameRoomService` 클래스에 `TraceClass` 데코레이터 적용.
* `BE/src/game/service/game.service.ts`: `GameService` 클래스에 `TraceClass` 데코레이터를 적용하고, 실행을 추적하기 위해 `longBusinessLogic` 메서드에 `Trace` 데코레이터 적용.
* `BE/src/game/service/quiz.cache.service.ts`: 메서드 호출을 추적하기 위해 `QuizCacheService` 클래스에 `TraceClass` 데코레이터 적용.

<br/>

## 🖼 참고 이미지

![image](https://github.com/user-attachments/assets/fabbaa80-1100-4e2c-b536-e175eb942311)

<br/>

## 🎯 리뷰 요구사항 (선택)

- 특별히 봐줬으면 하는 부분이 있다면 적어주세요

<br/>

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
