### PR TITLE
[BE] fix#275#276 소켓연결할때 error 발생시 서버가 죽는버그

### DIFF
--- a/BE/src/common/constants/exception-message.ts
+++ b/BE/src/common/constants/exception-message.ts
@@ -6,5 +6,7 @@ export const ExceptionMessage = {
   GAME_NOT_STARTED: '게임이 시작되지 않았습니다.',
   EXCEEDS_QUIZ_SET_LIMIT: '선택된 퀴즈 수가 퀴즈셋에 있는 퀴즈 수를 초과했습니다.',
   GAME_ALREADY_STARTED: '게임이 이미 시작되었습니다.',
-  PLAYER_NOT_FOUND: '존재하지 않는 플레이어입니다.'
+  PLAYER_NOT_FOUND: '존재하지 않는 플레이어입니다.',
+  CONNECTION_ERROR:
+    '\n소켓 연결시 title,gameMode,maxPlayerCount,isPublic 이 있어야 합니다. 또는 참가할 game-id가 있어야 합니다.'
 };

--- a/BE/src/game/game.gateway.ts
+++ b/BE/src/game/game.gateway.ts
@@ -161,7 +161,6 @@ export class GameGateway {
     });
   }
 
-  @UsePipes(new GameValidationPipe(SocketEvents.CHAT_MESSAGE))
   initialHeaders(headers, request) {
     if (!request.headers.cookie) {
       request.headers['player-id'] = this.setNewPlayerIdToCookie(headers);


### PR DESCRIPTION
## ➕ 이슈 번호

- #275 
- #276 

<br/>

## 🔎 작업 내용
이 Pull Request는 WebSocket 연결 프로세스의 에러 처리와 로깅을 개선하고, 약간의 코드 정리를 포함합니다. 가장 중요한 변경사항은 새로운 예외 메시지 추가, 사용자 친화적인 로깅 메시지 업데이트, 클라이언트 연결 중 에러 처리 강화입니다.

- 에러 처리 및 로깅 개선:
BE/src/common/constants/exception-message.ts: 소켓 연결 실패 시 더 자세한 정보를 제공하기 위해 새로운 예외 메시지 CONNECTION_ERROR를 추가했습니다.
BE/src/game/game.gateway.ts: handleConnection 메소드에 try-catch 블록을 추가하여 에러 처리를 개선했습니다. 이제 이 메소드는 에러를 로깅하고, 클라이언트에 에러 메시지를 전송하며, 실패 시 클라이언트 연결을 끊습니다.

- 코드 정리:
BE/src/game/game.gateway.ts: 코드베이스 정리를 위해 Server와 UseGuards와 같은 사용하지 않는 임포트를 제거했습니다.
BE/src/game/game.gateway.ts: 로그 메시지를 더 사용자 친화적으로 업데이트했습니다.

- 클래스 레벨에 Exception Filter가 작동하지 않았던 이유
원인 : engine.io(socket.io의 로우레벨)에서 connect event가 일어나기 때문에, 이시점에는 nestjs의 미들웨어가 로드되지 않은 시점이다! 따라서 우리가 만든 ExceptionFilter가 없는 시점에 생긴 error 이기 때문에 잡히지 않는것!
![image](https://github.com/user-attachments/assets/9aa1b742-5c62-4e34-9b4e-fb622aa44c2c)



<br/>

## 🖼 참고 이미지
쿼리파라미터가 없어도 서버가 죽지않음. 클라에게 에러 메시지 전송
![image](https://github.com/user-attachments/assets/51d32263-4906-4ddf-afd1-38274adc1ad0)

<br/>

## 🎯 리뷰 요구사항 (선택)

- 특별히 봐줬으면 하는 부분이 있다면 적어주세요

<br/>

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
