### PR TITLE
[BE] fix-room-clean

### DIFF
--- a/BE/src/game/redis/game-redis-memory.service.ts
+++ b/BE/src/game/redis/game-redis-memory.service.ts
@@ -26,7 +26,7 @@ export class GameRedisMemoryService {
    * 비활성 방을 체크하고 정리하는 크론 작업
    * SCAN을 사용하여 대규모 방 목록도 안전하게 처리
    */
-  @Cron(CronExpression.EVERY_SECOND)
+  @Cron(CronExpression.EVERY_10_MINUTES)
   async checkInactiveRooms(): Promise<void> {
     this.logger.verbose('비활성 방 체크 시작');
     try {

--- a/BE/src/game/redis/game-redis-memory.service.ts
+++ b/BE/src/game/redis/game-redis-memory.service.ts
@@ -1,13 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRedis } from '@nestjs-modules/ioredis';
 import Redis from 'ioredis';
-import { Cron, CronExpression } from '@nestjs/schedule';
 import { REDIS_KEY } from '../../common/constants/redis-key.constant';
+import { Cron, CronExpression } from '@nestjs/schedule';
 
 @Injectable()
 export class GameRedisMemoryService {
   private readonly logger = new Logger(GameRedisMemoryService.name);
   private readonly BATCH_SIZE = 100; // 한 번에 처리할 배치 크기
+  private readonly INACTIVE_THRESHOLD = 30 * 60 * 1000; // 30분 30 * 60 * 1000;
 
   private readonly TTL = {
     ROOM: 3 * 60 * 60,
@@ -19,10 +20,59 @@ export class GameRedisMemoryService {
   constructor(@InjectRedis() private readonly redis: Redis) {}
 
   /**
+   * 비활성 방 체크 (주기적으로 실행)
+   */
+  /**
+   * 비활성 방을 체크하고 정리하는 크론 작업
+   * SCAN을 사용하여 대규모 방 목록도 안전하게 처리
+   */
+  @Cron(CronExpression.EVERY_SECOND)
+  async checkInactiveRooms(): Promise<void> {
+    this.logger.verbose('비활성 방 체크 시작');
+    try {
+      const now = Date.now();
+      let cursor = '0';
+      let processedCount = 0;
+
+      do {
+        // SCAN을 사용하여 배치 단위로 처리
+        const [nextCursor, rooms] = await this.redis.sscan(
+          REDIS_KEY.ACTIVE_ROOMS,
+          cursor,
+          'COUNT',
+          this.BATCH_SIZE
+        );
+        cursor = nextCursor;
+
+        // 병렬로 방 상태 체크 및 처리
+        await Promise.all(
+          rooms.map(async (roomId) => {
+            try {
+              const lastActivity = await this.redis.hget(REDIS_KEY.ROOM(roomId), 'lastActivityAt');
+
+              if (lastActivity && now - parseInt(lastActivity) > this.INACTIVE_THRESHOLD) {
+                await this.redis.publish('room:cleanup', roomId);
+                this.logger.verbose(`비활성으로 인해 방 ${roomId} 정리 시작`);
+                processedCount++;
+              }
+            } catch (error) {
+              this.logger.error(`방 ${roomId} 처리 중 오류 발생: ${error.message}`);
+            }
+          })
+        );
+      } while (cursor !== '0');
+
+      this.logger.verbose(`비활성 방 체크 완료: ${processedCount}개 방 정리됨`);
+    } catch (error) {
+      this.logger.error(`비활성 방 체크 중 오류 발생: ${error.message}`);
+    }
+  }
+
+  /**
    * TTL 관리를 위한 스케줄러
    * 배치 처리로 블로킹 최소화
    */
-  @Cron(CronExpression.EVERY_MINUTE)
+  // @Cron(CronExpression.EVERY_SECOND)
   async manageTTL(): Promise<void> {
     try {
       // SCAN으로 활성 방 목록을 배치로 처리

--- a/BE/src/game/redis/subscribers/room.cleanup.subscriber.ts
+++ b/BE/src/game/redis/subscribers/room.cleanup.subscriber.ts
@@ -37,6 +37,15 @@ export class RoomCleanupSubscriber extends RedisSubscriber {
     try {
       const pipeline = this.redis.pipeline();
 
+      // 1. 방에 속한 플레이어 목록 가져오기, 200명미만 -> smembers 사용!
+      const players = await this.redis.smembers(REDIS_KEY.ROOM_PLAYERS(roomId));
+
+      // 2. 플레이어 데이터 삭제
+      for (const playerId of players) {
+        pipeline.del(REDIS_KEY.PLAYER(playerId)); // 플레이어 기본 데이터
+        pipeline.del(`${REDIS_KEY.PLAYER(playerId)}:Changes`); // 플레이어 Changes 데이터
+      }
+
       // 1. 방 관련 기본 데이터 삭제
       pipeline.del(REDIS_KEY.ROOM(roomId));
       pipeline.del(REDIS_KEY.ROOM_PLAYERS(roomId));

--- a/BE/src/game/service/game.room.service.ts
+++ b/BE/src/game/service/game.room.service.ts
@@ -8,7 +8,6 @@ import { generateUniquePin } from '../../common/utils/utils';
 import SocketEvents from '../../common/constants/socket-events';
 import { UpdateRoomOptionDto } from '../dto/update-room-option.dto';
 import { UpdateRoomQuizsetDto } from '../dto/update-room-quizset.dto';
-import { Cron, CronExpression } from '@nestjs/schedule';
 import { Socket } from 'socket.io';
 import { KickRoomDto } from '../dto/kick-room.dto';
 import { TraceClass } from '../../common/interceptor/SocketEventLoggerInterceptor';
@@ -17,7 +16,6 @@ import { TraceClass } from '../../common/interceptor/SocketEventLoggerIntercepto
 @Injectable()
 export class GameRoomService {
   private readonly logger = new Logger(GameRoomService.name);
-  private readonly INACTIVE_THRESHOLD = 30 * 60 * 1000; // 30분 30 * 60 * 1000;
   private readonly PLAYER_GRACE_PERIOD = 10; // 10초
 
   constructor(
@@ -255,24 +253,21 @@ export class GameRoomService {
     await pipeline.exec();
   }
 
-  /**
-   * 비활성 방 체크 (주기적으로 실행)
-   */
-  @Cron(CronExpression.EVERY_MINUTE)
-  async checkInactiveRooms(): Promise<void> {
-    const now = Date.now();
-    const rooms = await this.redis.smembers(REDIS_KEY.ACTIVE_ROOMS);
-    this.logger.verbose(`비활성 방 체크시작 / 활성 방 목록: ${rooms}`);
-
-    for (const roomId of rooms) {
-      const lastActivity = await this.redis.hget(REDIS_KEY.ROOM(roomId), 'lastActivityAt');
-
-      if (lastActivity && now - parseInt(lastActivity) > this.INACTIVE_THRESHOLD) {
-        await this.redis.publish('room:cleanup', roomId);
-        this.logger.verbose(`비활성으로 인해 방 ${roomId} 정리 시작`);
-      }
-    }
-  }
+  // @Cron(CronExpression.EVERY_MINUTE)
+  // async checkInactiveRooms(): Promise<void> {
+  //   const now = Date.now();
+  //   const rooms = await this.redis.smembers(REDIS_KEY.ACTIVE_ROOMS);
+  //   this.logger.verbose(`비활성 방 체크시작 / 활성 방 목록: ${rooms}`);
+  //
+  //   for (const roomId of rooms) {
+  //     const lastActivity = await this.redis.hget(REDIS_KEY.ROOM(roomId), 'lastActivityAt');
+  //
+  //     if (lastActivity && now - parseInt(lastActivity) > this.INACTIVE_THRESHOLD) {
+  //       await this.redis.publish('room:cleanup', roomId);
+  //       this.logger.verbose(`비활성으로 인해 방 ${roomId} 정리 시작`);
+  //     }
+  //   }
+  // }
 
   /**
    * 플레이어 관련 모든 데이터에 TTL 설정

--- a/BE/src/game/service/game.room.service.ts
+++ b/BE/src/game/service/game.room.service.ts
@@ -253,22 +253,6 @@ export class GameRoomService {
     await pipeline.exec();
   }
 
-  // @Cron(CronExpression.EVERY_MINUTE)
-  // async checkInactiveRooms(): Promise<void> {
-  //   const now = Date.now();
-  //   const rooms = await this.redis.smembers(REDIS_KEY.ACTIVE_ROOMS);
-  //   this.logger.verbose(`비활성 방 체크시작 / 활성 방 목록: ${rooms}`);
-  //
-  //   for (const roomId of rooms) {
-  //     const lastActivity = await this.redis.hget(REDIS_KEY.ROOM(roomId), 'lastActivityAt');
-  //
-  //     if (lastActivity && now - parseInt(lastActivity) > this.INACTIVE_THRESHOLD) {
-  //       await this.redis.publish('room:cleanup', roomId);
-  //       this.logger.verbose(`비활성으로 인해 방 ${roomId} 정리 시작`);
-  //     }
-  //   }
-  // }
-
   /**
    * 플레이어 관련 모든 데이터에 TTL 설정
    */


### PR DESCRIPTION
## 🔎 작업 내용

이 Pull Request는 Redis 기반 게임 서비스에서 비활성 방 처리와 정리 프로세스를 개선하기 위한 여러 업데이트를 포함합니다. 가장 중요한 변경사항은 비활성 방 확인을 위한 새로운 메소드 추가, 방 정리 프로세스 수정, 그리고 중복 코드 제거입니다.
- 비활성 방 처리 개선:
BE/src/game/redis/game-redis-memory.service.ts: cron 작업을 사용하여 주기적으로 비활성 방을 확인하고 정리하는 새로운 메소드 checkInactiveRooms를 추가했습니다. 이 메소드는 Redis SCAN을 사용하여 대규모 방 세트를 안전하게 처리하고 배치 단위로 처리합니다.

- 방 정리 프로세스 강화:
BE/src/game/redis/subscribers/room.cleanup.subscriber.ts: 방 정리 프로세스를 업데이트하여 방 데이터 자체뿐만 아니라 해당 방의 플레이어 목록을 가져와서 그들의 데이터도 삭제하도록 수정했습니다.

- 코드 정리 및 리팩토링:
BE/src/game/service/game.room.service.ts: GameRedisMemoryService의 새로운 구현으로 대체되었기 때문에 기존의 checkInactiveRooms 메소드와 관련 cron 작업을 제거했습니다.

- 사소한 변경사항:
BE/src/game/redis/game-redis-memory.service.ts: 일관된 구조를 따르도록 imports 순서를 재정렬했습니다.
BE/src/game/service/game.room.service.ts: 사용하지 않는 import 구문을 제거했습니다.

## 🖼 참고 이미지
- 퇴장전
![image](https://github.com/user-attachments/assets/b4ed035d-18e4-4c4b-bdab-3cc798e3a7b1)
- 마지막 플레이어 퇴장후
![image](https://github.com/user-attachments/assets/c23b669f-0980-4e41-9a94-a2aa623f449e)


<br/>

## 🎯 리뷰 요구사항 (선택)

- 특별히 봐줬으면 하는 부분이 있다면 적어주세요

<br/>

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
