### PR TITLE
[BE] fix: 서바이벌 모드 디버깅

### DIFF
--- a/BE/src/common/constants/game.ts
+++ b/BE/src/common/constants/game.ts
@@ -2,3 +2,8 @@ export enum GameMode {
   RANKING = 'RANKING',
   SURVIVAL = 'SURVIVAL',
 }
+
+export enum SurvivalStatus {
+  ALIVE = '1',
+  DEAD = '0',
+}

--- a/BE/src/game/dto/create-game.dto.ts
+++ b/BE/src/game/dto/create-game.dto.ts
@@ -1,7 +1,7 @@
 import { IsIn, IsInt, IsString, Max, MaxLength, Min, MinLength } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { WsException } from '@nestjs/websockets';
-import { GameMode } from '../../common/constants/game-mode';
+import { GameMode } from '../../common/constants/game';
 
 export class CreateGameDto {
   @IsString()

--- a/BE/src/game/dto/update-room-option.dto.ts
+++ b/BE/src/game/dto/update-room-option.dto.ts
@@ -1,7 +1,7 @@
 import { IsIn, IsInt, IsString, Length, Max, MaxLength, Min, MinLength } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { WsException } from '@nestjs/websockets';
-import { GameMode } from '../../common/constants/game-mode';
+import { GameMode } from '../../common/constants/game';
 
 export class UpdateRoomOptionDto {
   @IsString()

--- a/BE/src/game/service/game.chat.service.ts
+++ b/BE/src/game/service/game.chat.service.ts
@@ -7,6 +7,7 @@ import { REDIS_KEY } from '../../common/constants/redis-key.constant';
 import SocketEvents from '../../common/constants/socket-events';
 import { Namespace } from 'socket.io';
 import { TraceClass } from '../../common/interceptor/SocketEventLoggerInterceptor';
+import { SurvivalStatus } from '../../common/constants/game';
 
 @TraceClass()
 @Injectable()
@@ -56,7 +57,7 @@ export class GameChatService {
       const playerKey = REDIS_KEY.PLAYER(chatMessage.playerId);
       const isAlivePlayer = await this.redis.hget(playerKey, 'isAlive');
 
-      if (isAlivePlayer === '1') {
+      if (isAlivePlayer === SurvivalStatus.ALIVE) {
         server.to(gameId).emit(SocketEvents.CHAT_MESSAGE, chatMessage);
         return;
       }

--- a/BE/src/game/service/game.room.service.ts
+++ b/BE/src/game/service/game.room.service.ts
@@ -90,6 +90,12 @@ export class GameRoomService {
       client.join(gameId);
       client.emit(SocketEvents.GET_SELF_ID, { playerId: clientId });
       client.emit(SocketEvents.JOIN_ROOM, { players, isHost });
+
+      // 재접속한 플레이어의 socketId를 업데이트
+      await this.redis.hset(REDIS_KEY.PLAYER(clientId), {
+        socketId: client.id
+      });
+
       return;
     }
 
@@ -118,7 +124,8 @@ export class GameRoomService {
       positionY: positionY.toString(),
       disconnected: '0',
       gameId: gameId,
-      isAlive: SurvivalStatus.ALIVE
+      isAlive: SurvivalStatus.ALIVE,
+      socketId: client.id
     });
 
     await this.redis.zadd(REDIS_KEY.ROOM_LEADERBOARD(gameId), 0, clientId);

--- a/BE/src/game/service/game.room.service.ts
+++ b/BE/src/game/service/game.room.service.ts
@@ -11,6 +11,7 @@ import { UpdateRoomQuizsetDto } from '../dto/update-room-quizset.dto';
 import { Socket } from 'socket.io';
 import { KickRoomDto } from '../dto/kick-room.dto';
 import { TraceClass } from '../../common/interceptor/SocketEventLoggerInterceptor';
+import { SurvivalStatus } from '../../common/constants/game';
 
 @TraceClass()
 @Injectable()
@@ -117,7 +118,7 @@ export class GameRoomService {
       positionY: positionY.toString(),
       disconnected: '0',
       gameId: gameId,
-      isAlive: '1'
+      isAlive: SurvivalStatus.ALIVE
     });
 
     await this.redis.zadd(REDIS_KEY.ROOM_LEADERBOARD(gameId), 0, clientId);

--- a/BE/src/user/entities/user-quiz-archive.entity.ts
+++ b/BE/src/user/entities/user-quiz-archive.entity.ts
@@ -2,7 +2,7 @@ import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { BaseModel } from '../../common/entity/base.entity';
 import { QuizSetModel } from '../../quiz-set/entities/quiz-set.entity';
 import { UserModel } from './user.entity';
-import { GameMode } from '../../common/constants/game-mode';
+import { GameMode } from '../../common/constants/game';
 
 @Entity('user_quiz_archive')
 export class UserQuizArchiveModel extends BaseModel {


### PR DESCRIPTION
## ➕ 이슈 번호

- #이슈번호

<br/>

## 🔎 작업 내용

- 서바이벌 모드 끝난 이후 이동 안 되는 이슈 해결
  - 해결법: 게임 끝날 때 isAlive 모두 1로 처리
- 다 죽거나 1등만 남았을 때 게임 끝나게 처리
  - 해결법: Promise 관련 이슈 해결 
- 죽은자끼리 채팅 안 되는 현상 해결
  - 원인: playerId로 채팅을 하나하나 보내주는데, playerId가 socketId가 아니여서 발생
  - 해결법: redis에 player정보 넣을 때 socketId도 추가 
- '1', '0' 상수화

### [Promise 관련 이슈] 여기서 if문 안 통과될 수 있나? 

```tsx
// 생존 모드에서 모두 탈락하진 않았는지 체크
const players = await this.redis.smembers(REDIS_KEY.ROOM_PLAYERS(gameId));
const alivePlayers = players.filter(async (id) => {
  const isAlive = await this.redis.hget(REDIS_KEY.PLAYER(id), 'isAlive');
  return isAlive === '1';
});

// 게임 끝을 알림
if (quizList.length <= newQuizNum || alivePlayers.length === 0) {
```

- filter는 Promise 처리하지 못한다고 함
- 그래서 alivePlayers는 그대로 Promise 배열이 되어버림. 즉, 배열의 길이가 0일 수가 없음 
- map, filter, forEach 등은 비동기 처리를 기다리지 않음
- 그래서 아래처럼 Promise.all을 활용하거나, for문을 써야 함

### 이후 코드: Promise.all 활용

```tsx
const aliveCount = (await Promise.all(
  players.map(id => this.redis.hget(REDIS_KEY.PLAYER(id), 'isAlive'))
)).filter(isAlive => isAlive === '1').length;
```



<br/>

## 🎯 리뷰 요구사항 (선택)

- 특별히 봐줬으면 하는 부분이 있다면 적어주세요

<br/>

## ✅ Check List

- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
