### PR TITLE
[BE] hotfix#테스트용 api 삭제, fix db test

### DIFF
--- a/BE/src/InitDB/InitDB.controller.ts
+++ b/BE/src/InitDB/InitDB.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Post } from '@nestjs/common';
 import { InitDBService } from './InitDB.Service';
+import { Controller, HttpException, Post } from '@nestjs/common';
 
 @Controller('/api/initDB')
 export class InitDBController {
@@ -7,6 +7,7 @@ export class InitDBController {
 
   @Post()
   create() {
-    return this.initDBService.create();
+    throw new HttpException('test용 api 입니다.', 501);
+    // return this.initDBService.create();
   }
 }

--- a/BE/test/integration/quiz-set/quiz.integration.spec.ts
+++ b/BE/test/integration/quiz-set/quiz.integration.spec.ts
@@ -105,7 +105,7 @@ describe('QuizService', () => {
       // Given
       const createQuizSetDto: CreateQuizSetDto = {
         title: '자바스크립트 기초',
-        category: 'PROGRAMMING',
+        category: 'IT',
         quizList: [
           {
             quiz: 'JavaScript의 원시 타입이 아닌 것은?',
@@ -213,7 +213,7 @@ describe('QuizService', () => {
       // Given - 테스트 데이터 생성
       const createQuizSetDto: CreateQuizSetDto = {
         title: '자바스크립트 기초',
-        category: 'PROGRAMMING',
+        category: 'IT',
         quizList: [
           {
             quiz: '테스트 문제',
@@ -237,11 +237,11 @@ describe('QuizService', () => {
       await quizService.createQuizSet(createQuizSetDto, testUser.user);
 
       // When
-      const result = await quizService.findAllWithQuizzesAndChoices('PROGRAMMING', 0, 10, '');
+      const result = await quizService.findAllWithQuizzesAndChoices('IT', 0, 10, '');
 
       // Then
       expect(result.quizSetList).toBeDefined();
-      expect(result.quizSetList[0].category).toBe('PROGRAMMING');
+      expect(result.quizSetList[0].category).toBe('IT');
       expect(result.quizSetList[0].quizCount).toBe(1);
     });
 
@@ -294,7 +294,7 @@ describe('QuizService', () => {
       // Given - 테스트 데이터 생성
       const dto = {
         title: '테스트 퀴즈',
-        category: 'TEST',
+        category: 'IT',
         quizList: [
           {
             quiz: '문제1',
@@ -338,7 +338,7 @@ describe('QuizService', () => {
       // Given - 테스트용 퀴즈셋 생성
       const dto = {
         title: '원본 퀴즈',
-        category: 'TEST',
+        category: 'IT',
         quizList: [
           {
             quiz: '원본 문제',
@@ -362,7 +362,7 @@ describe('QuizService', () => {
       // Given
       const updateDto = {
         title: '수정된 퀴즈',
-        category: 'UPDATED',
+        category: 'IT',
         quizList: [
           {
             quiz: '수정된 문제',
@@ -385,7 +385,7 @@ describe('QuizService', () => {
       const updated = await quizService.findOne(originQuizSetId);
       expect(updated.id).toBe(originQuizSetId.toString());
       expect(updated.title).toBe('수정된 퀴즈');
-      expect(updated.category).toBe('UPDATED');
+      expect(updated.category).toBe('IT');
       expect(updated.quizList[0].quiz).toBe('수정된 문제');
       expect(updated.quizList[0].limitTime).toBe(60);
     });
@@ -409,7 +409,7 @@ describe('QuizService', () => {
       // Given - 테스트용 퀴즈셋 생성
       const dto = {
         title: '삭제될 퀴즈',
-        category: 'TEST',
+        category: 'IT',
         quizList: [
           {
             quiz: '문제',
@@ -458,7 +458,7 @@ async function createQuizSetTestData(
 ) {
   const createQuizSetDto: CreateQuizSetDto = {
     title: quizSetTitle,
-    category: 'PROGRAMMING',
+    category: 'IT',
     quizList: [
       {
         quiz: '테스트',


### PR DESCRIPTION

## 🔎 작업 내용
이 Pull Request는 `InitDB.controller.ts`와 `quiz.integration.spec.ts` 파일의 변경사항을 포함합니다. 
가장 중요한 변경사항은 `InitDBController`를 수정하여 `create` 메서드를 호출하는 대신 `HttpException`을 throw하도록 변경한 것과, 다양한 테스트 케이스에서 `category` 필드를 'IT'로 변경한 것입니다.

`InitDB.controller.ts` 변경사항:
* `InitDBController`의 `create` 메서드를 수정하여 'test용 api 입니다.'라는 메시지와 HTTP 상태 코드 501을 가진 `HttpException`을 throw하도록 변경했습니다.

`quiz.integration.spec.ts`의 테스트 케이스 업데이트:
* category에 있는 제약조건을 지키기 위해 여러 테스트 케이스에서 `category` 필드를 'PROGRAMMING' 또는 'TEST'에서 'IT'로 변경했습니다.

이러한 변경은 테스트용 API의 접근을 제한하고, 테스트 케이스의 카테고리를 일관되게 만드는 것이 목적입니다.

<br/>

## 🖼 참고 이미지

![image](https://github.com/user-attachments/assets/5db205e1-f177-4e9f-b23c-7e5663265c20)
![image](https://github.com/user-attachments/assets/16533064-1a72-47d5-b05e-d07e0e71b59f)

<br/>

## 🎯 리뷰 요구사항 (선택)

- 특별히 봐줬으면 하는 부분이 있다면 적어주세요

<br/>

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
