### PR TITLE
[BE] feat#329 퀴즈검색 성능개선

### DIFF
--- a/BE/src/InitDB/InitDB.controller.ts
+++ b/BE/src/InitDB/InitDB.controller.ts
@@ -1,5 +1,5 @@
 import { InitDBService } from './InitDB.Service';
-import { Controller, Post } from '@nestjs/common';
+import { Controller, HttpException, Post } from '@nestjs/common';
 
 @Controller('/api/initDB')
 export class InitDBController {
@@ -7,7 +7,7 @@ export class InitDBController {
 
   @Post()
   create() {
-    // throw new HttpException('test용 api 입니다.', 501);
-    return this.initDBService.create();
+    throw new HttpException('test용 api 입니다.', 501);
+    // return this.initDBService.create();
   }
 }

--- a/BE/src/InitDB/InitDB.controller.ts
+++ b/BE/src/InitDB/InitDB.controller.ts
@@ -1,5 +1,5 @@
 import { InitDBService } from './InitDB.Service';
-import { Controller, HttpException, Post } from '@nestjs/common';
+import { Controller, Post } from '@nestjs/common';
 
 @Controller('/api/initDB')
 export class InitDBController {
@@ -7,7 +7,7 @@ export class InitDBController {
 
   @Post()
   create() {
-    throw new HttpException('test용 api 입니다.', 501);
-    // return this.initDBService.create();
+    // throw new HttpException('test용 api 입니다.', 501);
+    return this.initDBService.create();
   }
 }

--- a/BE/src/InitDB/QUIZ_SET_TEST_DATA.ts
+++ b/BE/src/InitDB/QUIZ_SET_TEST_DATA.ts
@@ -175,7 +175,7 @@ export const QUIZ_SET_TEST_DATA = [
   },
   {
     title: '영어 문법 테스트',
-    category: 'ENGLISH',
+    category: 'LANGUAGE',
     quizList: [
       {
         quiz: '다음 중 현재완료 시제는?',

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -1,12 +1,10 @@
-import { config } from 'dotenv';
-import { join } from 'path';
 import 'pinpoint-node-agent';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { Logger } from '@nestjs/common';
 import { GameActivityInterceptor } from './game/interceptor/gameActivity.interceptor';
+
 // env 불러오기
-config({ path: join(__dirname, '..', '.env') }); // ../ 경로의 .env 로드
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/BE/src/quiz-set/entities/quiz-choice.entity.ts
+++ b/BE/src/quiz-set/entities/quiz-choice.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { QuizModel } from './quiz.entity';
 import { BaseModel } from '../../common/entity/base.entity';
 
@@ -11,6 +11,7 @@ export class QuizChoiceModel extends BaseModel {
   isAnswer: boolean;
 
   @Column({ name: 'choice_content', type: 'text' })
+  @Index({ fulltext: true })
   choiceContent: string;
 
   @Column({ name: 'choice_order', type: 'integer' })

--- a/BE/src/quiz-set/entities/quiz-choice.entity.ts
+++ b/BE/src/quiz-set/entities/quiz-choice.entity.ts
@@ -11,7 +11,10 @@ export class QuizChoiceModel extends BaseModel {
   isAnswer: boolean;
 
   @Column({ name: 'choice_content', type: 'text' })
-  @Index({ fulltext: true })
+  @Index({
+    fulltext: true,
+    parser: 'ngram'
+  })
   choiceContent: string;
 
   @Column({ name: 'choice_order', type: 'integer' })

--- a/BE/src/quiz-set/entities/quiz-set.entity.ts
+++ b/BE/src/quiz-set/entities/quiz-set.entity.ts
@@ -26,6 +26,10 @@ const CategoriesEnum = Object.freeze({
 @Entity('quiz_set')
 export class QuizSetModel extends BaseModel {
   @Column()
+  @Index({
+    fulltext: true,
+    parser: 'ngram' // ngram 파서 사용
+  }) // Full Text Search 인덱스 추가
   title: string;
 
   @Column({ name: 'user_id' })

--- a/BE/src/quiz-set/entities/quiz.entity.ts
+++ b/BE/src/quiz-set/entities/quiz.entity.ts
@@ -23,7 +23,10 @@ export class QuizModel extends BaseModel {
   quizSetId: number;
 
   @Column('text')
-  @Index({ fulltext: true })
+  @Index({
+    fulltext: true,
+    parser: 'ngram'
+  })
   quiz: string;
 
   @Column({ name: 'limit_time' })

--- a/BE/src/quiz-set/entities/quiz.entity.ts
+++ b/BE/src/quiz-set/entities/quiz.entity.ts
@@ -3,6 +3,7 @@ import {
   CreateDateColumn,
   DeleteDateColumn,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   OneToMany,
@@ -22,6 +23,7 @@ export class QuizModel extends BaseModel {
   quizSetId: number;
 
   @Column('text')
+  @Index({ fulltext: true })
   quiz: string;
 
   @Column({ name: 'limit_time' })

--- a/BE/src/quiz-set/quiz-set.controller.ts
+++ b/BE/src/quiz-set/quiz-set.controller.ts
@@ -44,13 +44,16 @@ export class QuizSetController {
     @Query('take', new ParseIntOrDefault(10)) take: number,
     @Query('search', new DefaultValuePipe('')) search: string
   ) {
+    const start = Date.now();
     const result = await this.quizService.findAllWithQuizzesAndChoices(
       category,
       cursor,
       take,
       search
     );
-    this.logger.verbose(`퀴즈셋 목록 조회: ${result}`);
+    const end = Date.now();
+    this.logger.verbose(`퀴즈셋 목록 조회: ${result}, ${end - start}ms`);
+    // this.logger.verbose(`퀴즈셋 목록 조회: ${result}`);
     return result;
   }
 

--- a/docs/db.MD
+++ b/docs/db.MD
@@ -1,15 +1,17 @@
-# Database Performance: Full Text Search Deep Dive
+# DB 성능개선: Full Text Search Deep Dive
 
-## Introduction
+## 개요
 
-데이터베이스에서 텍스트 검색을 구현할 때 가장 일반적으로 사용되는 LIKE 연산자는 큰 성능 이슈를 가져올 수 있습니다. 특히 `%keyword%` 패턴을 사용할 경우, 인덱스를 활용할 수 없어 전체 테이블 스캔이
-발생합니다. 이러한 문제를 해결하기 위한 Full Text Search에 대해 자세히 알아보겠습니다.
+데이터베이스에서 텍스트 검색을 구현할 때 가장 일반적으로 사용되는 LIKE 연산자는 큰 성능 이슈를 가져올 수 있습니다.
+<br>특히 `%keyword%` 패턴을 사용할 경우, 인덱스를 활용할 수 없어 전체 테이블 스캔이
+발생합니다.
+<br>이러한 문제를 해결하기 위한 Full Text Search에 대해 자세히 알아보겠습니다.
 
 ## 퀴즈 검색 개선
 
 ### 기존 방식
 
-- 게임을 시작하기 이전, 풀 퀴즈셋을 검색하고 선택<br>
+- 게임을 시작하기 전에 풀 퀴즈셋을 검색하고 선택<br>
   ![image](https://github.com/user-attachments/assets/a784e094-0b44-4b7f-8ab5-5166a1cfc87b)
 - 백엔드에서는 아래와 같은 쿼리 실행후 응답
 
@@ -20,11 +22,12 @@ WHERE (`quizSet`.`title` LIKE '%상식%' AND `quizSet`.`deletedAt` IS NULL)
   AND (`quizSet`.`deletedAt` IS NULL);
 ```
 
-이 쿼리의 문제점:
+기존방식의 문제점 :
 
 1. 인덱스 활용 불가
 2. 전체 테이블 스캔 필요
-3. 대용량 데이터에서 심각한 성능 저하
+3. 지금은 데이터가 적어 문제가 없지만, 데이터가 많아지면 성능 저하 발생 예상
+4. 성능이슈가 생길 수 있는 가능성을 미리 차단하고자 함
 
 ## 개선전 성능측정
 
@@ -61,6 +64,7 @@ FROM cte;
    ![image](https://github.com/user-attachments/assets/d94a8a2a-05d5-4473-b727-c86cfe818443)
    ![image](https://github.com/user-attachments/assets/8fe67897-0ec7-431e-9539-870d11483c34)
    ![image](https://github.com/user-attachments/assets/279c6a91-6964-4ae9-a625-e9b85fa4364e)
+   ![image](https://github.com/user-attachments/assets/f9fa03b5-f30b-4533-9ddd-633b2430248b)
    평균 500~600ms 소요 && Full Table Scan
 
 ## 개선방법
@@ -116,179 +120,233 @@ flowchart LR
 - "B로 시작하는 책" → 'B' 섹션으로 바로 이동 가능
 - "중간에 'art'가 들어가는 책" → 모든 책을 하나씩 확인해야 함
 
-## Full Text Search Overview
+## Full Text Search 알아보기
 
-Full Text Search(FTS)의 특징 :
+### Search Types
 
-1. **토큰화(Tokenization)**
-    - 텍스트를 개별 단어로 분리
-    - 불용어(stopwords) 제거
-    - 형태소 분석 지원
+1. **Natural Language Search**
 
-2. **인덱싱**
-    - 역인덱스(Inverted Index) 구조 사용
-    - 효율적인 검색 가능
-    - 공간은 더 필요하지만 검색 속도 대폭 향상
+```sql
+SELECT *
+FROM table
+WHERE MATCH (column) AGAINST('search terms');
+```
 
-## Implementation
+- 자연어 모드는 기본 검색 모드
+- 관련성(relevancy) 점수 반환
+- 불용어(stopwords) 무시
+- 3글자 미만 단어 무시 (기본설정)
+- 50% 이상 행에 나타나는 단어 무시
+
+2. **Boolean Mode**
+
+```sql
+SELECT *
+FROM table
+WHERE MATCH (column) AGAINST('search terms' IN BOOLEAN MODE);
+```
+
+특수 연산자 지원:
+
+- `+word`: 필수 포함
+- `-word`: 제외
+- `>word`: 관련성 점수 증가
+- `<word`: 관련성 점수 감소
+- `(*)`: 와일드카드
+- `"phrase"`: 정확한 구문 검색
+
+### Parsers
+
+1. **기본 파서**
+
+```sql
+ALTER TABLE table_name
+    ADD FULLTEXT INDEX index_name(column);
+```
+
+```sql
+유동훈은
+오늘도 코딩을 한다 -> 
+유동훈은 / 오늘도 / 코딩을 / 한다
+```
+
+- 단어 단위로 분리
+- 기본 불용어 처리
+- 최소/최대 단어 길이 적용
+- **단점 : '동훈'으로 검색시 검색불가능!!**
+
+2. **ngram 파서**
+
+```sql
+ALTER TABLE table_name
+    ADD FULLTEXT INDEX index_name(column) WITH PARSER ngram;
+```
+
+```sql
+유동훈은
+오늘도 코딩을 한다 -> 
+유동/ 동훈 / 훈은 / 은오 / 오늘 / 도코 / 코딩 / 딩을 / 을한 / 한다
+```
+
+- 문자 단위로 분리
+- 한중일 등 아시아 언어에 적합
+
+설정 선택 :
+
+- 관련성 점수가 필요없으므로 **Boolean Mode** 사용
+- 한글 서비스 이므로 **ngram** 파서 사용
+
+## 구현
 
 ### 1. MySQL Full Text Search 설정
 
 ```
-# 최소 토큰 길이설정(한글은 2단어부터 중요)
+# 최소 토큰 길이설정(한글은 2단어부터 중요한 의미)
 # etc/mysqld.cnf 수정
 innodb_ft_min_token_size = 2 
 ```
 
 ![image](https://github.com/user-attachments/assets/b9b32bc0-4042-4561-8d2c-c2ecba475ab1)
 
-```sql
--- Full Text Index 생성
-ALTER TABLE articles
-    ADD FULLTEXT INDEX ft_article_title_content (title, content);
-
--- ngram 파서 사용 (한글 검색시 필요)
-ALTER TABLE articles
-    ADD FULLTEXT INDEX ft_article_title_content (title, content) 
-WITH PARSER ngram;
-```
-
 ### 2. TypeORM Entity 설정
 
-```typescript
-@Entity('articles')
-export class Article {
-    @Column()
-    @Index({fulltext: true})
-    title: string;
+- db에서 설정하기보다는 코드단위에서 개발자가 파악하기 쉽도록 typescript 코드에서 설정
 
-    @Column()
-    @Index({fulltext: true})
-    content: string;
-}
+```typescript
+@Entity('quiz_set')
+export class QuizModel extends BaseModel {
+    @Column('text')
+    @Index({
+        fulltext: true,
+        parser: 'ngram'
+    })
+    title: string;
 ```
 
 ### 3. 검색 서비스 구현
 
 ```typescript
 @Injectable()
-export class SearchService {
-    constructor(
-        @InjectRepository(Article)
-        private readonly articleRepository: Repository<Article>
-    ) {
-    }
+export class QuizSetReadService {
+    private async findSearchTargetIdsFS(search: string): Promise<number[]> {
+        const searchQuery = `+"${search.split(' ').join('" +"')}"`;
 
-    async search(keyword: string): Promise<Article[]> {
-        return this.articleRepository
-            .createQueryBuilder('article')
-            .where('MATCH(article.title, article.content) AGAINST(:keyword IN BOOLEAN MODE)')
-            .setParameter('keyword', `${keyword}*`)
+        const quizSetIds = await this.quizSetRepository
+            .createQueryBuilder('quizSet')
+            .select('quizSet.id')
+            .where('MATCH(quizSet.title) AGAINST (:search IN BOOLEAN MODE)', {
+                search: searchQuery
+            })
+            .andWhere('quizSet.deletedAt IS NULL')
             .getMany();
+    ...
     }
-}
 ```
+
+## 믿었던 Full Text Search의 배신
+
+- like문의 결과 : 666ms
+  ![image](https://github.com/user-attachments/assets/f9fa03b5-f30b-4533-9ddd-633b2430248b)
+  ![image](https://github.com/user-attachments/assets/defbee5d-5874-4a9e-820b-769ad3c813bc)
+- Full Text Search 결과 : 723ms
+- 항상 Full Text Search 의 성능이 좋은것은 아님<br>
+  ![image](https://github.com/user-attachments/assets/edc79c14-f466-4044-9bb4-9a480e07da77)
+  ![image](https://github.com/user-attachments/assets/a9108bf5-5143-466c-91d2-384ba1bbeba7)
+
+- 추정원인
+    - test data가 과학퀴즈 #random int와 같은 매우 간단한 형식으로 되어있음
+    - Full Text Search는 token화 작업후 index를 탐색
+    - like문은 token화 작업이 없음
+    - token화 작업 오버헤드가 더 컸던 것으로 추정
+- 해결
+    - Full Text Search의 성능을 높이기 위해 실사용에 가까운 더 복잡한 데이터를 생성하여 테스트
+
+```sql
+SET SESSION cte_max_recursion_depth = 1000000; -- 원하는 숫자로 설정
+
+
+INSERT INTO quiz_set (title, createdAt, updatedAt, deletedAt, user_id, category)
+WITH RECURSIVE
+    cte(n) AS (SELECT 1
+               UNION ALL
+               SELECT n + 1
+               FROM cte
+               WHERE n < 100000),
+    title_components
+        AS (SELECT '인공지능과 빅데이터로 알아보는,4차 산업혁명 시대의 핵심,메타버스와 웹3.0이 만드는,양자컴퓨팅이 여는 새로운,블록체인과 암호화폐가 바꾸는,딥러닝과 강화학습으로 이해하는,데이터 사이언스로 분석하는,클라우드 컴퓨팅으로 확장하는,사물인터넷과 연결되는,분산시스템으로 구현하는' as modern_prefix,
+                   '기계학습과 신경망의 기초,빅데이터 분석과 시각화,양자역학과 상대성이론,유전자 알고리즘과 진화연산,뇌과학과 인지공학의 원리,네트워크 이론과 그래프 분석,확률통계와 데이터마이닝,알고리즘과 자료구조의 응용,시스템 설계와 아키텍처,보안과 암호화의 기본'               as core_topics,
+                   '시대를 선도하는 기술 혁신:,미래를 준비하는 핵심 역량:,산업 현장의 실전 응용:,차세대 기술의 패러다임:,혁신적 사고의 프레임워크:,디지털 전환의 핵심 동력:,지속 가능한 발전 전략:,창의적 문제 해결 방법론:,스마트 시대의 필수 지식:,글로벌 트렌드의 중심에서:'   as prefix_phrases)
+SELECT CASE
+           WHEN n % 5 = 0 THEN CONCAT(
+                   SUBSTRING_INDEX(SUBSTRING_INDEX(modern_prefix, ',', 1 + FLOOR(RAND() * 10)), ',', -1), ' ',
+                   '일반상식의 새로운 관점 | ',
+                   SUBSTRING_INDEX(SUBSTRING_INDEX(core_topics, ',', 1 + FLOOR(RAND() * 10)), ',', -1),
+                   ' | 기초부터 고급까지 파트 ', n
+                               )
+           WHEN n % 5 = 1 THEN CONCAT(
+                   SUBSTRING_INDEX(SUBSTRING_INDEX(prefix_phrases, ',', 1 + FLOOR(RAND() * 10)), ',', -1), ' ',
+                   '역사 속 혁신과 도전 | ',
+                   SUBSTRING_INDEX(SUBSTRING_INDEX(core_topics, ',', 1 + FLOOR(RAND() * 10)), ',', -1),
+                   ' | 시대별 변천사 제', n, '권'
+                               )
+           WHEN n % 5 = 2 THEN CONCAT(
+                   SUBSTRING_INDEX(SUBSTRING_INDEX(modern_prefix, ',', 1 + FLOOR(RAND() * 10)), ',', -1), ' ',
+                   '현대 과학의 최전선 | ',
+                   SUBSTRING_INDEX(SUBSTRING_INDEX(core_topics, ',', 1 + FLOOR(RAND() * 10)), ',', -1),
+                   ' | 이론과 실제 챕터 ', n
+                               )
+           WHEN n % 5 = 3 THEN CONCAT(
+                   SUBSTRING_INDEX(SUBSTRING_INDEX(prefix_phrases, ',', 1 + FLOOR(RAND() * 10)), ',', -1), ' ',
+                   '언어와 소통의 과학 | ',
+                   SUBSTRING_INDEX(SUBSTRING_INDEX(core_topics, ',', 1 + FLOOR(RAND() * 10)), ',', -1),
+                   ' | 글로벌 시대의 언어 시리즈 ', n
+                               )
+           ELSE
+               CONCAT(
+                       SUBSTRING_INDEX(SUBSTRING_INDEX(modern_prefix, ',', 1 + FLOOR(RAND() * 10)), ',', -1), ' ',
+                       'IT 기술의 혁신 | ',
+                       SUBSTRING_INDEX(SUBSTRING_INDEX(core_topics, ',', 1 + FLOOR(RAND() * 10)), ',', -1),
+                       ' | 디지털 대전환 에디션 ', n
+               )
+           END AS title, TIMESTAMP (DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) + INTERVAL FLOOR(RAND() * 86400) SECOND), TIMESTAMP (DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) + INTERVAL FLOOR(RAND() * 86400) SECOND), CASE WHEN RAND() < 0.1 THEN CURRENT_TIMESTAMP ELSE NULL
+END
+,
+   1,
+   CASE 
+       WHEN n % 5 = 0 THEN 'GENERAL'
+       WHEN n % 5 = 1 THEN 'HISTORY'
+       WHEN n % 5 = 2 THEN 'SCIENCE'
+       WHEN n % 5 = 3 THEN 'LANGUAGE'
+       ELSE 'IT'
+END
+FROM cte, title_components;
+```
+
+- full text search 결과
+  ![image](https://github.com/user-attachments/assets/ccbb95bd-c018-43d6-af65-fa1beb76bccc)
+  ![image](https://github.com/user-attachments/assets/1a4cf628-0ace-45e8-a332-b3902e47fb2b)
+- like문 결과
+  ![image](https://github.com/user-attachments/assets/a10c9d7a-7e96-46a2-90a9-fd0124d7b6a5)
 
 ## Performance Comparison
 
-실제 성능 테스트 결과:
+실제 성능 테스트 결과: 약 50%의 성능개선
 
-| 방식   | 100K 레코드 | 1M 레코드 | 10M 레코드 |
-|------|----------|--------|---------|
-| LIKE | 500ms    | 5s     | 50s     |
-| FTS  | 50ms     | 100ms  | 200ms   |
+| 방식   | 100만개 레코드 | 
+|------|-----------|
+| LIKE | 510ms     |
+| FTS  | 267ms     | 
 
-## Best Practices
+## 고려사항
 
-1. **인덱스 관리**
-    - 필요한 컬럼만 인덱싱
-    - 주기적인 인덱스 최적화
-   ```sql
-   OPTIMIZE TABLE articles;
-   ```
+- 조사같은 경우는 인덱스를 만들기 않도록 불용어 설정
 
-2. **검색 쿼리 최적화**
-    - Boolean Mode 활용
-    - 와일드카드 사용 최소화
-   ```sql
-   MATCH(title, content) AGAINST('+필수단어 -제외단어' IN BOOLEAN MODE)
-   ```
+## 요약
 
-3. **ngram 설정 최적화**
-   ```sql
-   SET GLOBAL innodb_ft_min_token_size = 2;
-   SET GLOBAL innodb_ft_server_stopword_table = '';
-   ```
+- Full Text Search는 텍스트 검색 성능을 대폭 향상시킬 수 있는 강력한 도구
+- 하지만 항상 like 문보다 성능이 좋은것은 아님 (data가 간단한 경우)
 
-## Common Pitfalls
-
-1. **과도한 인덱싱**
-    - 모든 텍스트 컬럼에 FTS 인덱스 적용
-    - 디스크 공간 낭비
-    - INSERT/UPDATE 성능 저하
-
-2. **잘못된 파서 선택**
-    - 한글 검색시 ngram 파서 미사용
-    - 부적절한 토큰 사이즈 설정
-
-3. **캐싱 전략 부재**
-    - 자주 사용되는 검색어 미캐싱
-    - 불필요한 DB 부하 발생
-
-## Advanced Topics
-
-### 1. Elasticsearch 도입 고려사항
-
-대규모 데이터나 복잡한 검색 요구사항이 있는 경우:
-
-```typescript
-@Injectable()
-export class ElasticsearchService {
-    async searchArticles(keyword: string) {
-        return this.elasticsearchClient.search({
-            index: 'articles',
-            body: {
-                query: {
-                    multi_match: {
-                        query: keyword,
-                        fields: ['title', 'content']
-                    }
-                }
-            }
-        });
-    }
-}
-```
-
-### 2. 하이브리드 검색 전략
-
-```typescript
-@Injectable()
-export class HybridSearchService {
-    async search(keyword: string) {
-        // 짧은 키워드는 FTS
-        if (keyword.length < 4) {
-            return this.searchWithFTS(keyword);
-        }
-        // 긴 키워드는 Elasticsearch
-        return this.searchWithElasticsearch(keyword);
-    }
-}
-```
-
-## Summary
-
-Full Text Search는 텍스트 검색 성능을 대폭 향상시킬 수 있는 강력한 도구입니다.
-하지만 적절한 설정과 최적화가 필요하며, 데이터 특성과 요구사항에 맞는 전략 선택이 중요합니다.
-
-## References
-
-- MySQL Full Text Search Documentation
-- TypeORM Documentation
-- Performance Optimization Guides
-- Elasticsearch Documentation
-
-## Additional Resources
+## 레퍼런스
 
 - [MySQL Full Text Search 공식 문서](https://dev.mysql.com/doc/refman/8.0/en/fulltext-search.html)
 - [한빛미디어 이것이 mysql 이다](https://www.youtube.com/watch?v=NGzrKnnCQUw)

--- a/docs/db.MD
+++ b/docs/db.MD
@@ -328,7 +328,7 @@ FROM cte, title_components;
 - like문 결과
   ![image](https://github.com/user-attachments/assets/a10c9d7a-7e96-46a2-90a9-fd0124d7b6a5)
 
-## Performance Comparison
+## 성능 비교
 
 실제 성능 테스트 결과: 약 50%의 성능개선
 
@@ -344,6 +344,7 @@ FROM cte, title_components;
 ## 요약
 
 - Full Text Search는 텍스트 검색 성능을 대폭 향상시킬 수 있는 강력한 도구
+- like문은 Full Table Scan을 유발할 수 있음
 - 하지만 항상 like 문보다 성능이 좋은것은 아님 (data가 간단한 경우)
 
 ## 레퍼런스

--- a/docs/db.MD
+++ b/docs/db.MD
@@ -119,6 +119,7 @@ flowchart LR
 
 - "B로 시작하는 책" → 'B' 섹션으로 바로 이동 가능
 - "중간에 'art'가 들어가는 책" → 모든 책을 하나씩 확인해야 함
+- **우리가 원하는것은 중간에 '과학' 이 들어가는 퀴즈를 찾는것**
 
 ## Full Text Search 알아보기
 
@@ -262,7 +263,7 @@ export class QuizSetReadService {
     - Full Text Search의 성능을 높이기 위해 실사용에 가까운 더 복잡한 데이터를 생성하여 테스트
 
 ```sql
-SET SESSION cte_max_recursion_depth = 1000000; -- 원하는 숫자로 설정
+SET SESSION cte_max_recursion_depth = 1000000;
 
 
 INSERT INTO quiz_set (title, createdAt, updatedAt, deletedAt, user_id, category)

--- a/docs/db.MD
+++ b/docs/db.MD
@@ -1,0 +1,294 @@
+# Database Performance: Full Text Search Deep Dive
+
+## Introduction
+
+데이터베이스에서 텍스트 검색을 구현할 때 가장 일반적으로 사용되는 LIKE 연산자는 큰 성능 이슈를 가져올 수 있습니다. 특히 `%keyword%` 패턴을 사용할 경우, 인덱스를 활용할 수 없어 전체 테이블 스캔이
+발생합니다. 이러한 문제를 해결하기 위한 Full Text Search에 대해 자세히 알아보겠습니다.
+
+## 퀴즈 검색 개선
+
+### 기존 방식
+
+- 게임을 시작하기 이전, 풀 퀴즈셋을 검색하고 선택<br>
+  ![image](https://github.com/user-attachments/assets/a784e094-0b44-4b7f-8ab5-5166a1cfc87b)
+- 백엔드에서는 아래와 같은 쿼리 실행후 응답
+
+```sql
+SELECT `quizSet`.`id` AS `quizSet_id`
+FROM `quiz_set` `quizSet`
+WHERE (`quizSet`.`title` LIKE '%상식%' AND `quizSet`.`deletedAt` IS NULL)
+  AND (`quizSet`.`deletedAt` IS NULL);
+```
+
+이 쿼리의 문제점:
+
+1. 인덱스 활용 불가
+2. 전체 테이블 스캔 필요
+3. 대용량 데이터에서 심각한 성능 저하
+
+## 개선전 성능측정
+
+1. 임의의 데이터 10만개 삽입
+
+```sql
+INSERT INTO quiz_set (title, createdAt, updatedAt, deletedAt, user_id, category)
+WITH RECURSIVE cte(n) AS (SELECT 1
+                          UNION ALL
+                          SELECT n + 1
+                          FROM cte
+                          WHERE n < 100000)
+SELECT CASE
+           WHEN n % 5 = 0 THEN CONCAT('일반상식 퀴즈 #', LPAD(n, 4, '0'))
+           WHEN n % 5 = 1 THEN CONCAT('역사 퀴즈 #', LPAD(n, 4, '0'))
+           WHEN n % 5 = 2 THEN CONCAT('과학 퀴즈 #', LPAD(n, 4, '0'))
+           WHEN n % 5 = 3 THEN CONCAT('문학 퀴즈 #', LPAD(n, 4, '0'))
+           ELSE CONCAT('시사 퀴즈 #', LPAD(n, 4, '0'))
+           END AS title, TIMESTAMP (DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) + INTERVAL FLOOR(RAND() * 86400) SECOND), TIMESTAMP (DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) + INTERVAL FLOOR(RAND() * 86400) SECOND), CASE WHEN RAND() < 0.1 THEN CURRENT_TIMESTAMP ELSE NULL
+END
+,
+    FLOOR(1 + RAND() * 100),
+    CASE 
+        WHEN n % 5 = 0 THEN 'GENERAL'
+        WHEN n % 5 = 1 THEN 'HISTORY'
+        WHEN n % 5 = 2 THEN 'SCIENCE'
+        WHEN n % 5 = 3 THEN 'LITERATURE'
+        ELSE 'CURRENT'
+END
+FROM cte;
+```
+
+2. api 호출
+   ![image](https://github.com/user-attachments/assets/d94a8a2a-05d5-4473-b727-c86cfe818443)
+   ![image](https://github.com/user-attachments/assets/8fe67897-0ec7-431e-9539-870d11483c34)
+   ![image](https://github.com/user-attachments/assets/279c6a91-6964-4ae9-a625-e9b85fa4364e)
+   평균 500~600ms 소요 && Full Table Scan
+
+## 개선방법
+
+### 퀴즈 검색 기능
+
+- 실시간 퀴즈 서비스에서 풀 퀴즈를 검색하는것은 필수적인 기능
+- 프로젝트 개발 기간이 제한적
+- Elasticsearch 등의 검색 엔진을 도입하기에는 시간적, 학습적 제약이 있음
+- 이미 도입된 기술스택인 MySQL의 Full Text Search을 활용하여 검색 성능을 향상시키는 방법을 선택
+
+### Like 연산자가 index 스캔이 안되는 이유
+
+'%text%'와 같은 패턴에서 검색할 문자열이 어디에 위치할지 모르기 때문에,
+데이터베이스 엔진은 모든 레코드를 확인해야함
+
+예시)
+
+```mermaid
+flowchart LR
+    subgraph "B-Tree Index"
+        direction TB
+        A["Apple"]
+        B["Banana"]
+        C["Cherry"]
+        D["Date"]
+    end
+
+    subgraph "LIKE 'B%' 검색"
+        direction TB
+        E["시작점 'B' 찾기"] --> F["'B'로 시작하는 항목 순차 검색"]
+    end
+
+    subgraph "LIKE '%ana%' 검색"
+        direction TB
+        G["첫 레코드 검사"] --> H["다음 레코드 검사"] --> I["모든 레코드 검사 필요"]
+    end
+
+```
+
+1. `LIKE 'B%'` 경우:
+    - 인덱스에서 'B'로 시작하는 위치를 찾음
+    - 그 위치부터 순차적으로 검색
+    - 효율적인 검색 가능
+
+2. `LIKE '%ana%'` 경우:
+    - 'ana'가 단어의 어느 위치에 있을지 모름
+    - 정렬된 인덱스를 활용할 수 없음
+    - 모든 레코드를 확인해야 함 (Full Table Scan)
+
+예시:
+
+- "B로 시작하는 책" → 'B' 섹션으로 바로 이동 가능
+- "중간에 'art'가 들어가는 책" → 모든 책을 하나씩 확인해야 함
+
+## Full Text Search Overview
+
+Full Text Search(FTS)의 특징 :
+
+1. **토큰화(Tokenization)**
+    - 텍스트를 개별 단어로 분리
+    - 불용어(stopwords) 제거
+    - 형태소 분석 지원
+
+2. **인덱싱**
+    - 역인덱스(Inverted Index) 구조 사용
+    - 효율적인 검색 가능
+    - 공간은 더 필요하지만 검색 속도 대폭 향상
+
+## Implementation
+
+### 1. MySQL Full Text Search 설정
+
+```
+# 최소 토큰 길이설정(한글은 2단어부터 중요)
+# etc/mysqld.cnf 수정
+innodb_ft_min_token_size = 2 
+```
+
+![image](https://github.com/user-attachments/assets/b9b32bc0-4042-4561-8d2c-c2ecba475ab1)
+
+```sql
+-- Full Text Index 생성
+ALTER TABLE articles
+    ADD FULLTEXT INDEX ft_article_title_content (title, content);
+
+-- ngram 파서 사용 (한글 검색시 필요)
+ALTER TABLE articles
+    ADD FULLTEXT INDEX ft_article_title_content (title, content) 
+WITH PARSER ngram;
+```
+
+### 2. TypeORM Entity 설정
+
+```typescript
+@Entity('articles')
+export class Article {
+    @Column()
+    @Index({fulltext: true})
+    title: string;
+
+    @Column()
+    @Index({fulltext: true})
+    content: string;
+}
+```
+
+### 3. 검색 서비스 구현
+
+```typescript
+@Injectable()
+export class SearchService {
+    constructor(
+        @InjectRepository(Article)
+        private readonly articleRepository: Repository<Article>
+    ) {
+    }
+
+    async search(keyword: string): Promise<Article[]> {
+        return this.articleRepository
+            .createQueryBuilder('article')
+            .where('MATCH(article.title, article.content) AGAINST(:keyword IN BOOLEAN MODE)')
+            .setParameter('keyword', `${keyword}*`)
+            .getMany();
+    }
+}
+```
+
+## Performance Comparison
+
+실제 성능 테스트 결과:
+
+| 방식   | 100K 레코드 | 1M 레코드 | 10M 레코드 |
+|------|----------|--------|---------|
+| LIKE | 500ms    | 5s     | 50s     |
+| FTS  | 50ms     | 100ms  | 200ms   |
+
+## Best Practices
+
+1. **인덱스 관리**
+    - 필요한 컬럼만 인덱싱
+    - 주기적인 인덱스 최적화
+   ```sql
+   OPTIMIZE TABLE articles;
+   ```
+
+2. **검색 쿼리 최적화**
+    - Boolean Mode 활용
+    - 와일드카드 사용 최소화
+   ```sql
+   MATCH(title, content) AGAINST('+필수단어 -제외단어' IN BOOLEAN MODE)
+   ```
+
+3. **ngram 설정 최적화**
+   ```sql
+   SET GLOBAL innodb_ft_min_token_size = 2;
+   SET GLOBAL innodb_ft_server_stopword_table = '';
+   ```
+
+## Common Pitfalls
+
+1. **과도한 인덱싱**
+    - 모든 텍스트 컬럼에 FTS 인덱스 적용
+    - 디스크 공간 낭비
+    - INSERT/UPDATE 성능 저하
+
+2. **잘못된 파서 선택**
+    - 한글 검색시 ngram 파서 미사용
+    - 부적절한 토큰 사이즈 설정
+
+3. **캐싱 전략 부재**
+    - 자주 사용되는 검색어 미캐싱
+    - 불필요한 DB 부하 발생
+
+## Advanced Topics
+
+### 1. Elasticsearch 도입 고려사항
+
+대규모 데이터나 복잡한 검색 요구사항이 있는 경우:
+
+```typescript
+@Injectable()
+export class ElasticsearchService {
+    async searchArticles(keyword: string) {
+        return this.elasticsearchClient.search({
+            index: 'articles',
+            body: {
+                query: {
+                    multi_match: {
+                        query: keyword,
+                        fields: ['title', 'content']
+                    }
+                }
+            }
+        });
+    }
+}
+```
+
+### 2. 하이브리드 검색 전략
+
+```typescript
+@Injectable()
+export class HybridSearchService {
+    async search(keyword: string) {
+        // 짧은 키워드는 FTS
+        if (keyword.length < 4) {
+            return this.searchWithFTS(keyword);
+        }
+        // 긴 키워드는 Elasticsearch
+        return this.searchWithElasticsearch(keyword);
+    }
+}
+```
+
+## Summary
+
+Full Text Search는 텍스트 검색 성능을 대폭 향상시킬 수 있는 강력한 도구입니다.
+하지만 적절한 설정과 최적화가 필요하며, 데이터 특성과 요구사항에 맞는 전략 선택이 중요합니다.
+
+## References
+
+- MySQL Full Text Search Documentation
+- TypeORM Documentation
+- Performance Optimization Guides
+- Elasticsearch Documentation
+
+## Additional Resources
+
+- [MySQL Full Text Search 공식 문서](https://dev.mysql.com/doc/refman/8.0/en/fulltext-search.html)
+- [한빛미디어 이것이 mysql 이다](https://www.youtube.com/watch?v=NGzrKnnCQUw)


### PR DESCRIPTION
## ➕ 이슈 번호

- #329

<br/>

## 🔎 작업 내용
- 문서 : https://github.com/boostcampwm-2024/web10-QuizGround/wiki/Full-Text-Search%EC%9D%84-%EC%9D%B4%EC%9A%A9%ED%95%9C-%ED%80%B4%EC%A6%88%EA%B2%80%EC%83%89-50%25-%EC%84%B1%EB%8A%A5%EA%B0%9C%EC%84%A0

이 PR은 백엔드 서비스의 여러 변경사항을 포함하며, 데이터베이스 초기화, 퀴즈셋 데이터 관리, 검색 기능 개선에 중점을 두었습니다. 가장 중요한 변경사항은 다음과 같습니다:

### 퀴즈셋 카테고리 제한:
* initDB api가 카테고리 제한때문에 오류를 뱉는 문제.
* `QUIZ_SET_TEST_DATA.ts`: "영어 문법 테스트" 퀴즈셋의 카테고리를 'ENGLISH'에서 'LANGUAGE'로 변경했습니다.

### 전문 검색(Full-Text Search) 개선:
* `quiz-choice.entity.ts`: `choiceContent` 컬럼에 `ngram` 파서를 사용하는 전문 검색 인덱스를 추가했습니다.
* `quiz-set.entity.ts`: `title` 컬럼에 `ngram` 파서를 사용하는 전문 검색 인덱스를 추가했습니다.
* `quiz.entity.ts`: `quiz` 컬럼에 `ngram` 파서를 사용하는 전문 검색 인덱스를 추가했습니다.

### 성능 로깅:
* `quiz-set.controller.ts`: 퀴즈셋 목록을 가져오는데 걸리는 시간을 측정하기 위한 성능 로깅을 추가했습니다.

### 코드베이스 단순화:
* `quiz-set-read.service.ts`: `findSearchTargetIds` 메서드를 전문 검색을 위한 `findSearchTargetIdsFS`를 사용하도록 리팩토링하고, 새로운 메서드에 대한 자세한 문서화와 성능 지표를 추가했습니다.


<br/>

## 🖼 참고 이미지

![image](https://github.com/user-attachments/assets/332483ed-c58d-4e9f-a624-1db006500de5)

<br/>

## 🎯 리뷰 요구사항 (선택)

- 특별히 봐줬으면 하는 부분이 있다면 적어주세요

<br/>

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
