### PR TITLE
[BE] feat#333 배치기능 모듈화

### DIFF
--- a/BE/src/game/redis/subscribers/player.subscriber.ts
+++ b/BE/src/game/redis/subscribers/player.subscriber.ts
@@ -6,12 +6,25 @@ import { Namespace } from 'socket.io';
 import SocketEvents from '../../../common/constants/socket-events';
 import { REDIS_KEY } from '../../../common/constants/redis-key.constant';
 import { SurvivalStatus } from '../../../common/constants/game';
+import { createBatchProcessor } from '../../service/BatchProcessor';
 import { MetricService } from '../../../metric/metric.service';
+
+// Position update interface
+interface PositionUpdate {
+  playerId: string;
+  playerPosition: [number, number];
+}
+
+// Chat message interface
+interface ChatMessage {
+  playerId: string;
+  message: string;
+  timestamp: Date;
+}
 
 @Injectable()
 export class PlayerSubscriber extends RedisSubscriber {
-  private positionUpdates: Map<string, any> = new Map(); // Map<gameId, {playerId, playerPosition}[]>
-  private positionUpdatesForDead: Map<string, any> = new Map(); // Map<gameId, {playerId, playerPosition}[]>
+  private positionProcessor: ReturnType<typeof createBatchProcessor>;
   private positionUpdatesMetrics: Map<string, any> = new Map(); // Map<gameId, {startedAt}[]>
 
   constructor(
@@ -22,16 +35,20 @@ export class PlayerSubscriber extends RedisSubscriber {
   }
 
   async subscribe(server: Namespace): Promise<void> {
+    // Create batch processor for position updates
+    this.positionProcessor = createBatchProcessor(server, SocketEvents.UPDATE_POSITION);
+    this.positionProcessor.startProcessing(100); // Start processing every 100ms
+
     const subscriber = this.redis.duplicate();
     await subscriber.psubscribe('__keyspace@0__:Player:*');
 
     subscriber.on('pmessage', async (_pattern, channel, message) => {
-      const startedAt = process.hrtime();
-
       const playerId = this.extractPlayerId(channel);
       if (!playerId || message !== 'hset') {
         return;
       }
+
+      const startedAt = process.hrtime();
       const playerKey = REDIS_KEY.PLAYER(playerId);
       const gameId = await this.redis.hget(playerKey, 'gameId');
       const changes = await this.redis.get(`${playerKey}:Changes`);
@@ -43,16 +60,7 @@ export class PlayerSubscriber extends RedisSubscriber {
 
       await this.handlePlayerChanges(changes, playerId, server);
     });
-
     setInterval(() => {
-      // 배치 처리
-      this.positionUpdates.forEach((queue, gameId) => {
-        if (queue.length > 0) {
-          const batch = queue.splice(0, queue.length); //O(N)
-          server.to(gameId).emit(SocketEvents.UPDATE_POSITION, batch);
-        }
-      });
-
       // 배치 처리에 관한 메트릭 측정
       this.positionUpdatesMetrics.forEach((metrics) => {
         if (metrics.length > 0) {
@@ -129,13 +137,7 @@ export class PlayerSubscriber extends RedisSubscriber {
     const isAlivePlayer = await this.redis.hget(REDIS_KEY.PLAYER(playerId), 'isAlive');
 
     if (isAlivePlayer === SurvivalStatus.ALIVE) {
-      // 1. Map에 배열을 만들고 set
-      if (!this.positionUpdates.has(gameId)) {
-        this.positionUpdates.set(gameId, []); // 빈 배열로 초기화
-      }
-      this.positionUpdates.get(gameId).push(updateData);
-
-      // server.to(gameId).emit(SocketEvents.UPDATE_POSITION, updateData);
+      this.positionProcessor.pushData(gameId, updateData);
     } else if (isAlivePlayer === SurvivalStatus.DEAD) {
       const players = await this.redis.smembers(REDIS_KEY.ROOM_PLAYERS(gameId));
       const pipeline = this.redis.pipeline();

--- a/BE/src/game/redis/subscribers/player.subscriber.ts
+++ b/BE/src/game/redis/subscribers/player.subscriber.ts
@@ -9,19 +9,6 @@ import { SurvivalStatus } from '../../../common/constants/game';
 import { createBatchProcessor } from '../../service/BatchProcessor';
 import { MetricService } from '../../../metric/metric.service';
 
-// Position update interface
-interface PositionUpdate {
-  playerId: string;
-  playerPosition: [number, number];
-}
-
-// Chat message interface
-interface ChatMessage {
-  playerId: string;
-  message: string;
-  timestamp: Date;
-}
-
 @Injectable()
 export class PlayerSubscriber extends RedisSubscriber {
   private positionProcessor: ReturnType<typeof createBatchProcessor>;

--- a/BE/src/game/service/BatchProcessor.ts
+++ b/BE/src/game/service/BatchProcessor.ts
@@ -1,0 +1,77 @@
+/**
+ * @fileoverview Functional batch processor factory
+ */
+import { Namespace } from 'socket.io';
+import { Logger } from '@nestjs/common';
+
+interface BatchData {
+  gameId: string;
+  data: any;
+}
+
+/**
+ * Creates a batch processor instance
+ */
+export function createBatchProcessor(server: Namespace, eventName: string) {
+  const logger = new Logger(`BatchProcessor:${eventName}`);
+  // 이 변수들은 클로저에 의해 보호됨
+  const batchMap = new Map<string, any[]>();
+  let isProcessing = false;
+
+  /**
+   * Pushes data to batch queue
+   */
+  const pushData = (gameId: string, data: any) => {
+    if (!batchMap.has(gameId)) {
+      batchMap.set(gameId, []);
+    }
+    batchMap.get(gameId).push(data);
+  };
+
+  /**
+   * Processes and emits all batched data
+   */
+  const processBatch = () => {
+    if (isProcessing) {
+      return;
+    }
+
+    isProcessing = true;
+    try {
+      batchMap.forEach((queue, gameId) => {
+        if (queue.length > 0) {
+          const batch = queue.splice(0, queue.length);
+          server.to(gameId).emit(eventName, batch);
+          logger.debug(`Processed ${batch.length} items for game ${gameId}`);
+        }
+      });
+    } catch (error) {
+      logger.error(`Error processing batch: ${error.message}`);
+    } finally {
+      isProcessing = false;
+    }
+  };
+
+  /**
+   * Starts automatic batch processing
+   */
+  const startProcessing = (interval: number = 100) => {
+    setInterval(processBatch, interval);
+    logger.verbose(`Started batch processor for ${eventName} with ${interval}ms interval`);
+  };
+
+  /**
+   * Clears all batched data
+   */
+  const clear = () => {
+    batchMap.clear();
+  };
+
+  // 외부에서 사용할 수 있는 public 메서드만 노출
+  return {
+    pushData,
+    processBatch,
+    startProcessing,
+    clear
+  };
+}


### PR DESCRIPTION
## ➕ 이슈 번호

- #333 

<br/>

## 🔎 작업 내용

이 PR은 게임 이벤트를 더 효율적으로 처리하기 위한 새로운 배치 처리 시스템을 도입합니다. 변경사항에는 배치 프로세서의 생성과 이를 플레이어 위치 업데이트 및 채팅 메시지 처리에 통합하는 내용이 포함되어 있습니다.

좀 더 자세히 설명하면:
배치 처리 시스템 도입으로 실시간 이벤트 처리의 효율성 향상
플레이어 위치 업데이트와 채팅 메시지를 배치로 처리하도록 개선
서버 부하 감소 및 성능 최적화 달성

이것은 게임의 실시간 처리 성능을 향상시키기 위한 주요 개선사항입니다.

### Batch Processing System:

변경사항을 크게 3부분으로 나누어 설명드리겠습니다:

1. **BatchProcessor 생성**
- `BE/src/game/service/BatchProcessor.ts` 파일에 새로운 `createBatchProcessor` 함수를 추가했습니다.
- 이 함수는 다양한 게임 이벤트에 대한 배치 처리기를 생성하고 관리합니다.
- 데이터 추가(pushData), 배치 처리(processBatch), 자동 처리 시작(startProcessing), 데이터 초기화(clear) 등의 메서드를 포함합니다.

2. **플레이어 위치 업데이트 통합**
- `BE/src/game/redis/subscribers/player.subscriber.ts` 파일에서 기존의 위치 업데이트 처리 방식을 새로운 배치 처리기로 교체했습니다.
- 위치 업데이트를 위한 배치 처리기를 생성하고, 100ms 간격으로 처리를 시작하도록 설정했습니다.
- 위치 데이터를 배치 처리기에 push하는 방식으로 변경되었습니다.

3. **채팅 메시지 통합**
- `BE/src/game/service/game.chat.service.ts` 파일에 배치 처리기를 통합했습니다.
- 채팅 메시지를 위한 새로운 배치 처리기를 생성하고, 50ms 간격으로 처리하도록 설정했습니다.
- 채팅 데이터를 배치 처리하는 방식으로 변경되었습니다.

이러한 변경은 성능 최적화를 위해 실시간 이벤트들을 배치로 처리하도록 개선한 것입니다. 특히 채팅의 경우 더 빠른 응답이 필요하므로 50ms로, 위치 업데이트는 100ms 간격으로 설정되어 있습니다.

<br/>

## 사용방법
- 배치를 원하는 서비스에 필드선언
![image](https://github.com/user-attachments/assets/8dd3a249-4507-4fac-9d6b-88c164118070)
- 초기화 (server instance 생성후)
![image](https://github.com/user-attachments/assets/9db13be4-66cb-4aff-8780-0c23c1bf7f2c)
- emit을 직접 브로드캐스팅 하는 대신, 배치 프로세서 사용
![image](https://github.com/user-attachments/assets/51830cd2-500f-416c-b642-ad9375614837)



## 🖼 참고 이미지
- 채팅 포스트맨 test 성공
![image](https://github.com/user-attachments/assets/755354c5-3fa9-409c-8d8b-fc063873ac77)

<br/>

## 🎯 리뷰 요구사항 (선택)

- 특별히 봐줬으면 하는 부분이 있다면 적어주세요

<br/>

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
